### PR TITLE
fix: wait for dynamic DOM elements in static sites tests

### DIFF
--- a/src/__tests__/large/monitoring/shared.ts
+++ b/src/__tests__/large/monitoring/shared.ts
@@ -157,6 +157,26 @@ export async function handleAgeVerification(page: Page): Promise<void> {
   }
 }
 
+// Static sites読み込み完了の待機 - 動的DOM生成対応
+export async function waitForStaticContent(page: Page, selectors: string[]): Promise<void> {
+  if (selectors.length === 0) return;
+
+  for (const selector of selectors) {
+    // まず高速チェック - 既に存在するか確認
+    const quickCheck = await page.locator(selector).count().catch(() => 0);
+    if (quickCheck > 0) {
+      continue;
+    }
+
+    // 一部のstatic sites (例: Amazon) は動的にDOM要素を生成する
+    // ページロード後もJavaScriptで要素を追加する場合があるため待機
+    await page.waitForSelector(selector, {
+      timeout: 10000,
+      state: 'attached'
+    });
+  }
+}
+
 // SPA読み込み完了の待機 - CI環境での年齢認証バイパス対応
 export async function waitForSPAContent(page: Page, selectors: string[]): Promise<void> {
   if (selectors.length === 0) return;

--- a/src/__tests__/large/monitoring/static-sites.test.ts
+++ b/src/__tests__/large/monitoring/static-sites.test.ts
@@ -32,9 +32,11 @@ staticSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox,
       // Static sites can proceed immediately after load
       await page.waitForLoadState('load');
 
-      // 各セレクタの存在確認
+      // 各セレクタの存在確認 (動的DOM生成を考慮して待機)
       for (const selector of selectors) {
         try {
+          // 動的に生成される可能性のある要素を待機
+          await page.waitForSelector(selector, { timeout: 10000, state: 'attached' });
           const element = page.locator(selector);
           const count = await element.count();
           expect(count).toBeGreaterThan(0);
@@ -65,9 +67,11 @@ staticSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox,
       // Static sites can proceed immediately after load
       await page.waitForLoadState('load');
 
-      // 各セレクタの存在確認
+      // 各セレクタの存在確認 (動的DOM生成を考慮して待機)
       for (const selector of selectors) {
         try {
+          // 動的に生成される可能性のある要素を待機
+          await page.waitForSelector(selector, { timeout: 10000, state: 'attached' });
           const element = page.locator(selector);
           const count = await element.count();
           expect(count).toBeGreaterThan(0);

--- a/src/__tests__/large/monitoring/static-sites.test.ts
+++ b/src/__tests__/large/monitoring/static-sites.test.ts
@@ -4,6 +4,7 @@ import {
   performHealthCheck,
   handleAgeVerification,
   waitForSPAContent,
+  waitForStaticContent,
   insertionTargets
 } from './shared';
 
@@ -32,11 +33,12 @@ staticSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox,
       // Static sites can proceed immediately after load
       await page.waitForLoadState('load');
 
-      // 各セレクタの存在確認 (動的DOM生成を考慮して待機)
+      // 動的DOM生成を考慮した待機 (一部のサイトはページロード後もJSで要素を生成する)
+      await waitForStaticContent(page, selectors);
+
+      // 各セレクタの存在確認
       for (const selector of selectors) {
         try {
-          // 動的に生成される可能性のある要素を待機
-          await page.waitForSelector(selector, { timeout: 10000, state: 'attached' });
           const element = page.locator(selector);
           const count = await element.count();
           expect(count).toBeGreaterThan(0);
@@ -67,11 +69,12 @@ staticSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox,
       // Static sites can proceed immediately after load
       await page.waitForLoadState('load');
 
-      // 各セレクタの存在確認 (動的DOM生成を考慮して待機)
+      // 動的DOM生成を考慮した待機 (一部のサイトはページロード後もJSで要素を生成する)
+      await waitForStaticContent(page, selectors);
+
+      // 各セレクタの存在確認
       for (const selector of selectors) {
         try {
-          // 動的に生成される可能性のある要素を待機
-          await page.waitForSelector(selector, { timeout: 10000, state: 'attached' });
           const element = page.locator(selector);
           const count = await element.count();
           expect(count).toBeGreaterThan(0);
@@ -101,7 +104,8 @@ staticSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox,
 
         for (const selector of selectors) {
           try {
-            // 動的に生成される可能性のある要素を待機
+            // 動的に生成される可能性のある要素を待機 (例: Amazon #navbar)
+            // 複数のfallback セレクターを試すため、個別に待機
             await page.waitForSelector(selector.trim(), { timeout: 10000, state: 'attached' });
             const element = page.locator(selector.trim()).first();
             const count = await element.count();

--- a/src/__tests__/large/monitoring/static-sites.test.ts
+++ b/src/__tests__/large/monitoring/static-sites.test.ts
@@ -104,13 +104,22 @@ staticSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox,
 
         for (const selector of selectors) {
           try {
+            const trimmedSelector = selector.trim();
+
+            // 高速チェック - 既に存在するか確認
+            const quickCheck = await page.locator(trimmedSelector).first().count().catch(() => 0);
+            if (quickCheck > 0) {
+              console.log(`✓ Found insertion target for ${service}: ${trimmedSelector}`);
+              found = true;
+              break;
+            }
+
             // 動的に生成される可能性のある要素を待機 (例: Amazon #navbar)
-            // 複数のfallback セレクターを試すため、個別に待機
-            await page.waitForSelector(selector.trim(), { timeout: 10000, state: 'attached' });
-            const element = page.locator(selector.trim()).first();
+            await page.waitForSelector(trimmedSelector, { timeout: 10000, state: 'attached' });
+            const element = page.locator(trimmedSelector).first();
             const count = await element.count();
             if (count > 0) {
-              console.log(`✓ Found insertion target for ${service}: ${selector.trim()}`);
+              console.log(`✓ Found insertion target for ${service}: ${trimmedSelector}`);
               found = true;
               break;
             }

--- a/src/__tests__/large/monitoring/static-sites.test.ts
+++ b/src/__tests__/large/monitoring/static-sites.test.ts
@@ -101,6 +101,8 @@ staticSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox,
 
         for (const selector of selectors) {
           try {
+            // 動的に生成される可能性のある要素を待機
+            await page.waitForSelector(selector.trim(), { timeout: 10000, state: 'attached' });
             const element = page.locator(selector.trim()).first();
             const count = await element.count();
             if (count > 0) {


### PR DESCRIPTION
## Summary
- Amazon (Japanese)のテストでDOM要素が見つからない問題を修正
- ページロード後に動的に生成される要素を待機するため、`waitForSelector`を追加

## Background
CI環境（Daily Tests）で以下のエラーが発生していました:
```
Error: ❌ [STRUCTURE_ERROR] Amazon (Japanese) - Selector not found: #navbar
```

## Root Cause
Amazonのページは`waitForLoadState('load')`の後も、JavaScriptで動的にDOM要素（特に`#navbar`）を生成しています。そのため、ページロード直後にセレクターをチェックすると、要素がまだ存在せず、テストが失敗していました。

## Solution
`static-sites.test.ts`のセレクターチェック処理に`waitForSelector`を追加し、動的に生成される要素を待機するようにしました:

```typescript
// 動的に生成される可能性のある要素を待機
await page.waitForSelector(selector, { timeout: 10000, state: 'attached' });
```

## Test Results
手元での全てのstatic sitesテストが成功することを確認:
- Amazon (Japanese): ✅ (Chromium & Firefox)
- 他の全static sites: ✅

## Related
- Fixes CI failures in Daily Tests (Large & VPN)
- Affects all static sites tests, particularly Amazon (Japanese)

🤖 Generated with [Claude Code](https://claude.com/claude-code)