### PR TITLE
fix: mark Surugaya as requiring Japan IP due to Cloudflare restriction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ src/popup/popup.html
 # claude
 CLAUDE.local.md
 settings.local.json
+.claude/
 
 # playwright and testing
 playwright-report/

--- a/src/__tests__/large/monitoring/shared.ts
+++ b/src/__tests__/large/monitoring/shared.ts
@@ -467,7 +467,7 @@ export const staticSites: SiteConfig[] = [
     ],
     isStatic: true,
     skipFirefox: false,
-    requiresJapanIP: false,
+    requiresJapanIP: true, // Cloudflare blocks non-Japan IPs with HTTP 403
   },
   {
     service: "Toranoana",


### PR DESCRIPTION
## Summary
- Surugaya がCloudflareの地理的制限でCI環境（米国IP）からHTTP 403でブロックされている問題を修正
- `requiresJapanIP: true`に変更し、VPN接続問題を適切に検出できるようにした

## Changes
- `src/__tests__/large/monitoring/shared.ts`: Surugayaの設定を`requiresJapanIP: true`に変更

## Background
CI環境で以下のエラーが発生：
- HTTP 403エラー（Cloudflareによるブロック）
- Page Title: "Just a moment..."（Cloudflare challenge page）
- `cf-ray`ヘッダーが確認される

## Test plan
- [x] ローカルで動作確認
- [ ] CI環境でVPN接続時にテストが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)