### PR TITLE
fix: handle campaign label in FANZA Doujin title extraction

### DIFF
--- a/src/scraping/fanza-doujin-scraper.ts
+++ b/src/scraping/fanza-doujin-scraper.ts
@@ -43,9 +43,18 @@ export function scrapeFanzaDoujinData(document: Document): FanzaDoujinScrapedDat
     log(`Title selector failed: ${selector}`);
   }
 
-  const title = titleElement ? titleElement.innerText
-    .replace(/【.*】/, "")
-    .trim() : "";
+  // キャンペーン情報を除外してタイトルを取得
+  let title = "";
+  if (titleElement) {
+    // キャンペーンspanを除外するためにクローンを作成
+    const clonedElement = titleElement.cloneNode(true) as HTMLElement;
+    const campaignSpan = clonedElement.querySelector('.productTitle__txt--campaign');
+    if (campaignSpan) {
+      campaignSpan.remove();
+      log('Removed campaign span from title');
+    }
+    title = clonedElement.innerText.trim();
+  }
 
   if (!title) {
     log('❌ No title found with any selector');


### PR DESCRIPTION
## Summary
- キャンペーンラベル除去の正規表現 `/【.*】/` が greedy マッチにより、タイトル全体を削除してしまうバグを修正
- 例: `【50%OFF】 【時間停止】人間操作リモコン3【若返り】` → 空文字になっていた
- 正規表現の代わりにDOM操作でキャンペーン用 span のみを削除する方式に変更

## Test plan
- [ ] d_648674 のタイトルが正しく取得されること（`【時間停止】人間操作リモコン3【若返り】`）
- [ ] キャンペーンラベルなしの通常タイトルが影響を受けないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)