### PR TITLE
[codex] Fix DLsite Maniax ASMR scraping

### DIFF
--- a/src/__tests__/small/scraping/dlsite-maniax-scraper.test.ts
+++ b/src/__tests__/small/scraping/dlsite-maniax-scraper.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "@jest/globals";
+import {
+  DLSITE_MANIAX_ASMR_TYPE,
+  scrapeDLsiteManiaxData,
+} from "../../../scraping/dlsite-maniax-scraper";
+
+describe("scrapeDLsiteManiaxData", () => {
+  test("extracts ASMR details when cells contain layout whitespace and no 作者 row", () => {
+    const makeAnchor = (textContent: string) => ({ textContent });
+    const makeCell = (textContent: string, links: string[] = []) => {
+      const anchors = links.map(makeAnchor);
+
+      return {
+        textContent,
+        querySelector: (selector: string) =>
+          selector === ".maker_name a" ? anchors[0] || null : null,
+        querySelectorAll: (selector: string) =>
+          selector === "a" ? anchors : [],
+      };
+    };
+    const makeRow = (label: string, value: string, links: string[] = []) => ({
+      cells: [makeCell(label), makeCell(value, links)],
+    });
+    const makeTable = (rows: ReturnType<typeof makeRow>[]) => ({ rows });
+
+    const document = {
+      location: {
+        href: "https://www.dlsite.com/maniax/work/=/product_id/RJ01591453.html",
+      },
+      getElementById: (id: string) => {
+        const elements: Record<string, unknown> = {
+          work_name: {
+            textContent:
+              "【心情代弁特化】グラドルJK姉妹の鍵垢バレ童貞いじめドスケベエッチ！",
+          },
+          work_maker: makeTable([
+            makeRow("サークル名", "\n カモネギちゃんねる \n", [
+              "カモネギちゃんねる",
+            ]),
+          ]),
+          work_outline: makeTable([
+            makeRow("販売日", "2026年06月06日", ["2026年06月06日"]),
+            makeRow("シナリオ", "\n カモネギ \n", ["カモネギ"]),
+            makeRow("イラスト", "\n 郁 \n", ["郁"]),
+            makeRow("声優", "\n まあ油るる \n", ["まあ油るる"]),
+            makeRow("作品形式", "\n ボイス・ASMR \n", ["ボイス・ASMR"]),
+          ]),
+        };
+
+        return elements[id] || null;
+      },
+    } as unknown as Document;
+
+    const result = scrapeDLsiteManiaxData(document);
+
+    expect(result).toBeTruthy();
+    expect(result?.type).toBe(DLSITE_MANIAX_ASMR_TYPE);
+    expect(result?.circleName).toBe("カモネギちゃんねる");
+    expect(result?.authors).toEqual([]);
+    expect(result?.writers).toEqual(["カモネギ"]);
+    expect(result?.illustrators).toEqual(["郁"]);
+    expect(result?.voiceActors).toEqual(["まあ油るる"]);
+    expect(result?.publishedAt).toEqual(new Date("2026-06-06"));
+  });
+});

--- a/src/contentScript/DLsiteManiax.tsx
+++ b/src/contentScript/DLsiteManiax.tsx
@@ -6,7 +6,10 @@ import { BaseContentScript } from "./BaseContentScript";
 import Doujinshi from "../Doujinshi";
 import Asmr from "../Asmr";
 import Product from "../Product";
-import { scrapeDLsiteManiaxData } from "../scraping/dlsite-maniax-scraper";
+import {
+  DLSITE_MANIAX_ASMR_TYPE,
+  scrapeDLsiteManiaxData,
+} from "../scraping/dlsite-maniax-scraper";
 
 /**
  * DLSite maniaxやがるまに
@@ -40,7 +43,7 @@ class DLsiteManiax extends BaseContentScript {
     const publishedAt = dayjs(scrapedData.publishedAt);
 
     switch (scrapedData.type) {
-      case "ボイス・ASMR":
+      case DLSITE_MANIAX_ASMR_TYPE:
         return Asmr.make(
           AcceptedService.dlsiteManiax,
           scrapedData.title,

--- a/src/scraping/dlsite-maniax-scraper.ts
+++ b/src/scraping/dlsite-maniax-scraper.ts
@@ -2,6 +2,8 @@
  * Pure function to scrape DLsite Maniax data from the DOM
  */
 
+export const DLSITE_MANIAX_ASMR_TYPE = "ボイス・ASMR";
+
 export interface DLsiteManiaxScrapedData {
   title: string;
   type: string;
@@ -15,13 +17,18 @@ export interface DLsiteManiaxScrapedData {
   url: string;
 }
 
-export function scrapeDLsiteManiaxData(document: Document): DLsiteManiaxScrapedData | null {
+export function scrapeDLsiteManiaxData(
+  document: Document,
+): DLsiteManiaxScrapedData | null {
   try {
     const titleElement = document.getElementById("work_name");
     if (!titleElement) return null;
 
-    const title = titleElement.textContent?.trim() || '';
-    const url = document.location?.href || '';
+    const normalizeText = (value: string | null | undefined): string =>
+      value?.replace(/\s+/g, " ").trim() || "";
+
+    const title = normalizeText(titleElement.textContent);
+    const url = document.location?.href || "";
 
     const table = document.getElementById("work_maker");
     const outlineTable = document.getElementById("work_outline");
@@ -29,43 +36,59 @@ export function scrapeDLsiteManiaxData(document: Document): DLsiteManiaxScrapedD
     if (!table || !outlineTable) return null;
 
     // Helper function to get element from table if left header matches
-    const getElemIfExists = (leftHeaderStr: string, sourceTable: HTMLElement): string | null => {
+    const getCellIfExists = (
+      leftHeaderStr: string,
+      sourceTable: HTMLElement,
+    ): HTMLTableCellElement | null => {
       const rows = Array.from((sourceTable as HTMLTableElement).rows);
       const filtered = rows.filter(
-        (row) => row.cells[0]?.textContent === leftHeaderStr,
+        (row) => normalizeText(row.cells[0]?.textContent) === leftHeaderStr,
       );
       if (filtered.length > 0) {
-        return filtered[0].cells[1]?.textContent || null;
+        return filtered[0].cells[1] || null;
       }
       return null;
+    };
+
+    const getElemIfExists = (
+      leftHeaderStr: string,
+      sourceTable: HTMLElement,
+    ): string | null => {
+      const cell = getCellIfExists(leftHeaderStr, sourceTable);
+      return cell ? normalizeText(cell.textContent) : null;
+    };
+
+    const getLinkedNamesIfExists = (
+      leftHeaderStr: string,
+      sourceTable: HTMLElement,
+    ): string[] => {
+      const cell = getCellIfExists(leftHeaderStr, sourceTable);
+      if (!cell) return [];
+
+      const names = Array.from(cell.querySelectorAll("a"))
+        .map((anchor) => normalizeText(anchor.textContent))
+        .filter((name) => name.length > 0);
+
+      return names;
     };
 
     const type = getElemIfExists("作品形式", outlineTable) || "";
 
     // Parse authors, voice actors, illustrators, and writers
-    const authorsStr = getElemIfExists("作者", outlineTable);
-    const authors = authorsStr?.split("/").map((s) => s.trim()).filter(s => s) || [];
+    const authors = getLinkedNamesIfExists("作者", outlineTable);
 
-    const voiceActorsStr = getElemIfExists("声優", outlineTable);
-    const voiceActors = voiceActorsStr?.split("/").map((s) => s.trim()).filter(s => s) || [];
+    const voiceActors = getLinkedNamesIfExists("声優", outlineTable);
 
-    const illustratorsStr = getElemIfExists("イラスト", outlineTable);
-    const illustrators = illustratorsStr?.split("/").map((s) => s.trim()).filter(s => s) || [];
+    const illustrators = getLinkedNamesIfExists("イラスト", outlineTable);
 
-    const writersStr = getElemIfExists("シナリオ", outlineTable);
-    const writers = writersStr?.split("/").map((s) => s.trim()).filter(s => s) || [];
+    const writers = getLinkedNamesIfExists("シナリオ", outlineTable);
 
     // Extract circle name (remove follow button text and additional UI text)
-    const circleNameRaw = getElemIfExists("サークル名", table);
-    let circleName = "";
-    if (circleNameRaw) {
-      // Remove everything after newline, "フォローする", and numbers
-      circleName = circleNameRaw
-        .split('\n')[0] // Take first line only
-        .replace(/\s*フォローする.*$/, '') // Remove "フォローする" and everything after
-        .replace(/\s+\d+.*$/, '') // Remove numbers and everything after
-        .trim();
-    }
+    const circleName =
+      normalizeText(
+        getCellIfExists("サークル名", table)?.querySelector(".maker_name a")
+          ?.textContent,
+      ) || "";
 
     const eventName = getElemIfExists("イベント", outlineTable);
 
@@ -89,7 +112,7 @@ export function scrapeDLsiteManiaxData(document: Document): DLsiteManiaxScrapedD
       url,
     };
   } catch (error) {
-    console.error('Error scraping DLsite Maniax data:', error);
+    console.error("Error scraping DLsite Maniax data:", error);
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- Normalize DLsite Maniax table header/value text before matching or returning scraped values
- Extract Maniax staff fields from their actual linked table cells and read circle names from `.maker_name a`
- Share the ASMR type literal between scraping and product selection so `ボイス・ASMR` pages use the ASMR template
- Add a focused small test for the RJ01591453-style DOM shape

## Root Cause

DLsite renders values such as `作品形式` and `サークル名` inside table cells with layout whitespace and nested links. The previous scraper returned raw `textContent`, so `ボイス・ASMR` did not exactly match the content script switch case and fell through to the Doujinshi template. Circle extraction also split on a leading newline and produced an empty string.

## Notes

Claude consultation agreed that whitespace normalization is the root fix. Based on that review, this PR avoids broad `シナリオ + イラスト -> 著者` fallback behavior; when DLsite has no `作者` row, the ASMR-specific fields carry those staff names instead of duplicating them into `著者`.

## Validation

- `npm run test:small`
- `npm run build:chrome`
