### PR TITLE
[codex] Update Claude review instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ manifest.jsonとpackage.jsonを更新した上でリリースのPRを作り、ma
 - masterにpushしてはいけません。masterへの変更は必ずPRを作成してください
 - commitの前には必ずfmtすること
 - 外部サーバーとのテストを確認する際には、時間節約のため失敗したものに限って実行すること
-- PRを作成すると、Claude Codeによるレビューが行われます。一定時間待った後にコメントを確認し、criticalなコメントがあれば修正してpushすること。
+- PR作成時にGitHub Actions上のClaude Code自動レビューは走りません。必要なレビューは `subagent-consultation` スキルを使って依頼し、criticalな指摘があれば修正してpushすること。
 # HTML要素が変わってスクレイピングに失敗する場合
 対象サイトのHTMLをplaywright等で確認し、適切な情報が取れるようにscrapingロジックを書き直してください
 セレクターは想像で書かずに、実際のHTMLを見て確認すること。またfallbackは設定しないこと（なくなったら実際のサイトに接続するテストが落ちるのが理想）


### PR DESCRIPTION
## Summary
- Update CLAUDE.md to reflect that GitHub Actions no longer runs automated Claude Code reviews.
- Instruct maintainers to use the subagent-consultation skill when a review is needed.

## Validation
- Not run; documentation-only change.
- npm run fmt was not run because the fmt script only targets ts/tsx/scss files.