### PR TITLE
refactor: unify content script DOM waiting (Phase 4 PR-A)

### DIFF
--- a/src/__tests__/small/contentScript/base-content-script-message.test.ts
+++ b/src/__tests__/small/contentScript/base-content-script-message.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, expect, jest, test } from "@jest/globals";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { parseHTML } from "linkedom";
 import browser from "webextension-polyfill";
 import { BaseContentScript } from "../../../contentScript/BaseContentScript";
 import { AcceptedService } from "../../../constant";
@@ -80,4 +88,77 @@ test("検索エラーを受け取った場合はバーを描画しない", async
   await Promise.resolve();
 
   expect(script.createdBars).toBe(0);
+});
+
+describe("動的描画サイト (waitForDynamicContent)", () => {
+  let originalDocument: unknown;
+
+  // BaseContentScript の動的待ちは default root = document.body を使うため、
+  // linkedom の document を globalThis に差し込む。
+  const setGlobalDocument = (document: Document) => {
+    originalDocument = (globalThis as { document?: Document }).document;
+    (globalThis as { document?: Document }).document = document;
+  };
+
+  afterEach(() => {
+    (globalThis as { document?: unknown }).document = originalDocument;
+  });
+
+  class DynamicScript extends BaseContentScript {
+    protected readonly SERVICE = AcceptedService.fanza;
+    protected readonly waitForDynamicContent = true;
+    protected readonly scrapeTimeoutMs = 50;
+
+    constructor(private readonly doc: Document) {
+      super();
+    }
+
+    protected scrape(): Product | null {
+      return this.doc.querySelector("#ready") ? makeProduct("おそ作") : null;
+    }
+
+    protected createElementForBar(): void {
+      // このテストでは描画前の sendMessage 呼び出しだけを検証する
+    }
+  }
+
+  test("即時scrape失敗後、DOM変化でscrapeが成功したら検索する", async () => {
+    const { document } = parseHTML(
+      "<!DOCTYPE html><html><body></body></html>",
+    );
+    setGlobalDocument(document as unknown as Document);
+
+    new DynamicScript(document as unknown as Document).execute();
+
+    // まだ本文がないので検索していない
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+
+    const ready = document.createElement("div");
+    ready.id = "ready";
+    document.body.appendChild(ready);
+
+    // observer コールバック -> searchAndRender の sendMessage まで待つ
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      action: SearchBibliographyAction,
+      query: "おそ作",
+    });
+  });
+
+  test("DOMが変化してもscrapeが成功しなければ検索しない", async () => {
+    const { document } = parseHTML(
+      "<!DOCTYPE html><html><body></body></html>",
+    );
+    setGlobalDocument(document as unknown as Document);
+
+    new DynamicScript(document as unknown as Document).execute();
+
+    // #ready ではない要素を追加しても scrape は失敗のまま
+    document.body.appendChild(document.createElement("span"));
+    // timeout を超えるまで待ち、observer/timer が後始末されることも確認する
+    await new Promise((resolve) => setTimeout(resolve, 80));
+
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+  });
 });

--- a/src/__tests__/small/contentScript/wait-for-scrape.test.ts
+++ b/src/__tests__/small/contentScript/wait-for-scrape.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "@jest/globals";
+import { parseHTML } from "linkedom";
+import {
+  waitForElement,
+  waitForScrape,
+} from "../../../contentScript/dom/waitForScrape";
+
+// jsdom は parse5 の ESM/CJS 境界で jest が読めないため、
+// scraper-fixtures テストと同様に linkedom で DOM を組み立てる。
+function makeDom(): Document {
+  const { document } = parseHTML(
+    "<!DOCTYPE html><html><body></body></html>",
+  );
+  return document as unknown as Document;
+}
+
+describe("waitForScrape", () => {
+  test("scrapeが即座に非nullを返す場合は即解決する", async () => {
+    const document = makeDom();
+    let calls = 0;
+
+    const result = await waitForScrape(
+      () => {
+        calls += 1;
+        return "ready";
+      },
+      { root: document.body },
+    );
+
+    expect(result).toBe("ready");
+    // 即時成功なのでMutationObserverを待つ追加呼び出しは発生しない
+    expect(calls).toBe(1);
+  });
+
+  test("初回nullでもDOM変化後にscrapeが成功すれば解決する", async () => {
+    const document = makeDom();
+
+    const promise = waitForScrape(
+      () => document.querySelector("h1")?.textContent ?? null,
+      { root: document.body, timeoutMs: 1000 },
+    );
+
+    // DOMがまだないので未解決。後からh1を追加する
+    const h1 = document.createElement("h1");
+    h1.textContent = "タイトル";
+    document.body.appendChild(h1);
+
+    const result = await promise;
+    expect(result).toBe("タイトル");
+  });
+
+  test("timeoutMsを超えてもscrapeが成功しなければnullで解決する", async () => {
+    const document = makeDom();
+
+    const result = await waitForScrape(() => null, {
+      root: document.body,
+      timeoutMs: 30,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("timeout後はobserverが解除され、その後のDOM変化で再scrapeしない", async () => {
+    const document = makeDom();
+    let calls = 0;
+
+    const result = await waitForScrape(
+      () => {
+        calls += 1;
+        return null;
+      },
+      { root: document.body, timeoutMs: 20 },
+    );
+    expect(result).toBeNull();
+
+    const callsAtTimeout = calls;
+    // 解除されていれば、この変化では scrape は呼ばれない
+    document.body.appendChild(document.createElement("div"));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(calls).toBe(callsAtTimeout);
+  });
+});
+
+describe("waitForElement", () => {
+  test("既に存在する要素は即座に返す", async () => {
+    const document = makeDom();
+    const existing = document.createElement("div");
+    existing.id = "target";
+    document.body.appendChild(existing);
+
+    const result = await waitForElement("#target", { root: document.body });
+
+    expect(result).toBe(existing);
+  });
+
+  test("後から追加された要素を待って返す", async () => {
+    const document = makeDom();
+
+    const promise = waitForElement("#late", {
+      root: document.body,
+      timeoutMs: 1000,
+    });
+
+    const late = document.createElement("div");
+    late.id = "late";
+    document.body.appendChild(late);
+
+    const result = await promise;
+    expect(result).toBe(late);
+  });
+
+  test("見つからなければtimeout後にnullを返す", async () => {
+    const document = makeDom();
+
+    const result = await waitForElement("#missing", {
+      root: document.body,
+      timeoutMs: 30,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/contentScript/BaseContentScript.tsx
+++ b/src/contentScript/BaseContentScript.tsx
@@ -11,6 +11,7 @@ import {
   SearchBibliographyResponseDto,
   SearchResultDto,
 } from "../scrapbox/searchDtos";
+import { waitForScrape } from "./dom/waitForScrape";
 
 /**
  * Content Scriptに必要な処理を集約したクラス
@@ -19,6 +20,15 @@ export abstract class BaseContentScript {
   protected readonly ROOT_ELEM = "uniBarRoot";
   // これらは必ず実装してください
   protected readonly SERVICE: AcceptedService;
+
+  /**
+   * BFF / SPA で本文が後から描画されるサイトは true にする。
+   * true の場合、即時 scrape に失敗しても DOM の変化を監視して再 scrape する。
+   */
+  protected readonly waitForDynamicContent: boolean = false;
+
+  /** 動的描画を待つ場合のタイムアウト（ミリ秒）。 */
+  protected readonly scrapeTimeoutMs: number = 10000;
 
   /**
    * 開いたページから必要な情報をスクレイピングする
@@ -35,12 +45,25 @@ export abstract class BaseContentScript {
   protected abstract createElementForBar(): void;
 
   execute() {
+    // 静的サイトと、本文が即時に存在する一般的なケースはここで完結する。
     const product = this.scrape();
-    if (!product) {
+    if (product) {
+      void this.searchAndRender(product);
       return;
     }
 
-    void this.searchAndRender(product);
+    // 即時 scrape に失敗した場合、動的描画サイトのみ DOM 変化を待って再 scrape する。
+    if (!this.waitForDynamicContent) {
+      return;
+    }
+
+    void waitForScrape(() => this.scrape(), {
+      timeoutMs: this.scrapeTimeoutMs,
+    }).then((delayedProduct) => {
+      if (delayedProduct) {
+        return this.searchAndRender(delayedProduct);
+      }
+    });
   }
 
   protected async searchAndRender(product: Product): Promise<void> {

--- a/src/contentScript/FanzaAnime.tsx
+++ b/src/contentScript/FanzaAnime.tsx
@@ -9,6 +9,8 @@ import { scrapeFanzaAnimeData } from "../scraping/fanza-anime-scraper";
 
 class FanzaAnime extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.fanzaAnime;
+  // SPAで本文が後から描画されるため、DOMの変化を待って再scrapeする。
+  protected readonly waitForDynamicContent = true;
 
   protected createElementForBar(): void {
     const rootElement = this.createRootElement();
@@ -21,42 +23,11 @@ class FanzaAnime extends BaseContentScript {
   }
 
   protected scrape(): Film | null {
-    console.log("[FanzaAnime] Starting scrape process...");
-
-    // Try immediate scraping first
-    let scrapedData = scrapeFanzaAnimeData(document);
-    if (scrapedData) {
-      console.log(
-        "[FanzaAnime] Immediate scraping successful:",
-        scrapedData.title,
-      );
-      return this.createFilm(scrapedData);
+    const scrapedData = scrapeFanzaAnimeData(document);
+    if (!scrapedData) {
+      return null;
     }
 
-    console.log(
-      "[FanzaAnime] Immediate scraping failed, waiting for SPA content...",
-    );
-
-    // Wait for SPA content using MutationObserver
-    this.waitForSPAContent().then((success) => {
-      if (success) {
-        const delayedData = scrapeFanzaAnimeData(document);
-        if (delayedData) {
-          console.log(
-            "[FanzaAnime] Delayed scraping successful:",
-            delayedData.title,
-          );
-          // Re-execute the content script flow with the new data
-          this.handleDelayedScraping(delayedData);
-        }
-      }
-    });
-
-    // Return null for now, delayed scraping will handle success case
-    return null;
-  }
-
-  private createFilm(scrapedData: any): Film {
     return Film.make(
       AcceptedService.fanzaAnime,
       scrapedData.title,
@@ -67,48 +38,6 @@ class FanzaAnime extends BaseContentScript {
       scrapedData.label,
       scrapedData.manufacturerProductNumber,
     );
-  }
-
-  private async waitForSPAContent(): Promise<boolean> {
-    console.log("[FanzaAnime] Setting up MutationObserver for SPA content...");
-
-    return new Promise((resolve) => {
-      const timeout = setTimeout(() => {
-        observer.disconnect();
-        console.log("[FanzaAnime] SPA content wait timeout");
-        resolve(false);
-      }, 10000); // 10 second timeout
-
-      const observer = new MutationObserver((mutations) => {
-        // Check if h1 elements have been added
-        const h1Elements = document.querySelectorAll("h1");
-        if (h1Elements.length > 0) {
-          console.log(
-            "[FanzaAnime] SPA content detected, h1 elements found:",
-            h1Elements.length,
-          );
-          clearTimeout(timeout);
-          observer.disconnect();
-          resolve(true);
-        }
-      });
-
-      observer.observe(document.body, {
-        childList: true,
-        subtree: true,
-      });
-    });
-  }
-
-  private handleDelayedScraping(scrapedData: any): void {
-    console.log("[FanzaAnime] Handling delayed scraping results...");
-
-    const film = this.createFilm(scrapedData);
-    console.log("[FanzaAnime] Created film object:", film.title);
-
-    this.searchAndRender(film);
-
-    console.log("[FanzaAnime] Delayed scraping flow initiated");
   }
 }
 

--- a/src/contentScript/FanzaBooks.tsx
+++ b/src/contentScript/FanzaBooks.tsx
@@ -11,6 +11,9 @@ import { scrapeFanzaBooksData } from "../scraping/fanza-books-scraper";
  */
 class FanzaBooks extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.fanza;
+  // 2023年4月ごろのアップデートでBFFで後から動的に情報を取得するようになったため、
+  // DOMの変化を待って再scrapeする。
+  protected readonly waitForDynamicContent = true;
 
   /**
    * バー表示用のdiv要素を生成
@@ -47,10 +50,5 @@ class FanzaBooks extends BaseContentScript {
   }
 }
 
-// 2023年4月ごろのアップデートでBFFで後から動的に情報を取得するようになった
-// これに対応するためにはMutationObserverを使い、対象のDOMが更新されたのかをwatchする必要がある
-// そんなコードを書くのは面倒なので1秒まつ
-setTimeout(function () {
-  const f = new FanzaBooks();
-  f.execute();
-}, 3000); // 2000ミリ秒（2秒）待機する
+const f = new FanzaBooks();
+f.execute();

--- a/src/contentScript/FanzaVideo.tsx
+++ b/src/contentScript/FanzaVideo.tsx
@@ -9,6 +9,8 @@ import { scrapeFanzaVideoData } from "../scraping/fanza-video-scraper";
 
 class FanzaVideo extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.fanzaVideo;
+  // 本文が後から動的に描画されるため、DOMの変化を待って再scrapeする。
+  protected readonly waitForDynamicContent = true;
 
   protected createElementForBar(): void {
     const rootElement = this.createRootElement();
@@ -50,8 +52,5 @@ class FanzaVideo extends BaseContentScript {
   }
 }
 
-// FanzaBooksと同様にDOMの読み込み完了を待つ
-setTimeout(function () {
-  const f = new FanzaVideo();
-  f.execute();
-}, 3000); // 3秒待機
+const f = new FanzaVideo();
+f.execute();

--- a/src/contentScript/dom/waitForScrape.ts
+++ b/src/contentScript/dom/waitForScrape.ts
@@ -1,0 +1,67 @@
+export type WaitForScrapeOptions = {
+  /** これを超えたら null で解決する。デフォルト 10 秒。 */
+  timeoutMs?: number;
+  /** 監視対象のルート要素。デフォルトは document.body。 */
+  root?: ParentNode & Node;
+};
+
+/**
+ * `scrapeFn` が非nullを返すまで待つ。
+ *
+ * 1. まず即時に1回試す。
+ * 2. nullなら `root` のDOM変化を MutationObserver で監視し、変化のたびに再試行する。
+ * 3. `timeoutMs` を超えても成功しなければ null で解決する。
+ *
+ * blind な `setTimeout` 固定待ちや独自 polling を置き換えるための共通待ち関数。
+ */
+export function waitForScrape<T>(
+  scrapeFn: () => T | null,
+  options: WaitForScrapeOptions = {},
+): Promise<T | null> {
+  const immediate = scrapeFn();
+  if (immediate != null) {
+    return Promise.resolve(immediate);
+  }
+
+  const { timeoutMs = 10000 } = options;
+  const root = options.root ?? document.body;
+  const doc = root.ownerDocument ?? (root as Document);
+  const ObserverCtor =
+    doc.defaultView?.MutationObserver ?? globalThis.MutationObserver;
+
+  return new Promise<T | null>((resolve) => {
+    let settled = false;
+
+    const finish = (value: T | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      observer.disconnect();
+      resolve(value);
+    };
+
+    const observer = new ObserverCtor(() => {
+      const result = scrapeFn();
+      if (result != null) {
+        finish(result);
+      }
+    });
+    observer.observe(root, { childList: true, subtree: true });
+
+    const timer = setTimeout(() => finish(null), timeoutMs);
+  });
+}
+
+/**
+ * `selector` に一致する要素が現れるまで待つ。
+ * `waitForScrape` の薄いラッパ。
+ */
+export function waitForElement(
+  selector: string,
+  options: WaitForScrapeOptions = {},
+): Promise<Element | null> {
+  return waitForScrape(
+    () => (options.root ?? document.body).querySelector(selector),
+    options,
+  );
+}


### PR DESCRIPTION
## 概要

リファクタリング計画 [docs/refactoring-plan.md](../blob/main/docs/refactoring-plan.md) の **Phase 4「Content Script 共通化」の PR-A** として、各詳細ページ content script に散在していた DOM 待ちロジックを共通ヘルパーに統一します。

これまで DOM 待ちは3方式が混在していました:
- `setTimeout(3000)` の固定待ち（FanzaBooks / FanzaVideo）
- 独自 `MutationObserver`（FanzaAnime の `waitForSPAContent` / `handleDelayedScraping`）
- 即時 scrape のみ（その他の静的サイト）

## 変更内容

- **`src/contentScript/dom/waitForScrape.ts` を新設**
  - `waitForScrape(scrapeFn, opts)`: まず即時に1回試し、null なら `root` の DOM 変化を `MutationObserver` で監視して変化のたびに再 scrape、`timeoutMs`（既定10秒）を超えたら null で解決。`settled` フラグ + `clearTimeout` + `observer.disconnect()` で後始末。
  - `waitForElement(selector, opts)`: 上記の薄いラッパ。
- **`BaseContentScript.execute()` を1フローに統一**
  - 即時 scrape 成功でこれまで通り完結（静的サイトの挙動は完全保存）。
  - 失敗時は `waitForDynamicContent = true` のサイトのみ DOM 変化を待って再 scrape。
- **Fanza 3サイトを宣言的に**
  - FanzaBooks / FanzaVideo: `setTimeout(3000)` を廃止し `waitForDynamicContent = true`。
  - FanzaAnime: 独自 observer 実装と多数の `console.log` を廃止し `waitForDynamicContent = true`。

## 挙動への影響

- 静的サイトは即時 scrape のみで従来通り（動的待ちはオプトイン）。
- Fanza の遅延描画サイトは「3秒固定待ち / h1出現監視」から「scrape 成功まで DOM 変化を監視（最大10秒）」へ。取りこぼしはむしろ減る方向。

## テスト

- jsdom は parse5 の ESM/CJS 境界で jest が読めないため、既存 fixture テストと同様に **linkedom** を使用。
- `waitForScrape` / `waitForElement`: 即時成功・遅延成功・timeout・timeout後の observer 解除を検証。
- `BaseContentScript`: 動的待ちで「DOM変化→scrape成功で検索」「変化しても成功しなければ非検索」を検証。
- `npm run test:small`（102件）/ `npm run build:chrome` / `npm run dep:check` 全通過。

## レビュー

`subagent-consultation` でレビュー済み。critical / major の指摘なし。指摘された minor（`waitForElement` の root 二重解決、後始末テストの強化）は本PRに反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)