### PR TITLE
refactor: complete content script commonization phase 4

### DIFF
--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -6,7 +6,8 @@
 > Phase 7a（ビルド/エントリ基盤の方針決定 ADR）は完了済み。WXT を採用方針とし、Phase 5 では自前 generator を作り込まない。
 > Phase 6（フィクスチャテストの導入）は主要対象の実ページ由来 HTML fixture と Small characterization test を追加済み。
 > Phase 3（Scraper 契約の統一）は完了済み。`publishedAt` の `Date | null` 統一、scraped data 型の集約、scraper logging 集約、Amazon publisher parse 修正、Amazon speculative fallback selector 削減を追加済み。
-> Phase 2（Product 責務分離）は完了。`titleForSearch` と Scrapbox placeholder formatter を pure domain function として `src/domain` に抽出し、`createScrapboxBodyString` を storage 非依存の同期 pure メソッド化、全角→半角変換を `src/domain/halfWidth.ts` に集約、各 product class の default format を `{token}` 化して toTemplateVars 経由の1経路に統一済み。Phase 4（Content Script 共通化）は着手済み。
+> Phase 2（Product 責務分離）は完了。`titleForSearch` と Scrapbox placeholder formatter を pure domain function として `src/domain` に抽出し、`createScrapboxBodyString` を storage 非依存の同期 pure メソッド化、全角→半角変換を `src/domain/halfWidth.ts` に集約、各 product class の default format を `{token}` 化して toTemplateVars 経由の1経路に統一済み。
+> Phase 4（Content Script 共通化）は完了。次の作業対象は Phase 5。
 > 今後はフル Clean Architecture ではなく、uni の規模に合わせた **DDD-lite + 最小 port 境界** を採用する。
 
 ## 0. 現在地
@@ -154,7 +155,7 @@ hampu と同じ考え方で、方向性チェックをCIに入れる。
 
 **Phase 7a → Phase 6 → Phase 3 → Phase 2 → Phase 4 → Phase 5 → Phase 7b → Phase 8**
 
-Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 は完了済みとして扱う。現在の作業対象は Phase 4。
+Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 は完了済みとして扱う。次の作業対象は Phase 5。
 
 ### Phase 1.5 — 検索境界の完全 DTO 化と sendMessage 一本化（完了）
 
@@ -304,7 +305,7 @@ CI強化:
 - `src/domain` 作成後、`domain-must-stay-browser-free` が実効ルールになる。
 - `Product.ts` が `browser` を import しなくなったため、root `Product` 系に `products-must-not-import-storage-keys`（`chromeApi.ts` と `src/settings/` 禁止。settings 経由で storage 読込を間接的に復活させないため）と `products-must-not-import-extension-runtime`（`webextension-polyfill` 禁止）を追加済み。
 
-### Phase 4 — Content Script共通化
+### Phase 4 — Content Script共通化（完了）
 
 目的:
 
@@ -317,11 +318,12 @@ CI強化:
 - 詳細ページ系 content script の mount selector / position / fallback / prepare 処理を `rootElementMountPoint` の宣言的設定へ寄せ、単純な `createElementForBar()` override を撤去。
 - 詳細ページ系 content script を `DetailContentScript<TScrapedData>` に寄せ、`scrapeData()` と `createProduct()` を分離。`publishedAt` の dayjs 変換も基底側に集約。
 - 一覧ページ系（DMMBasket / DLsiteCart）の Scrapbox リンク表示と `ScrapboxPageDto -> 表示リンク` mapping を `cartScrapboxLinks.tsx` に集約。
+- 一覧ページ系（DMMBasket / DLsiteCart）の storage 読込、polling、MutationObserver、per-item 検索、リンク container 描画を `CartScrapboxChecker.tsx` に集約し、各 entry はサイト固有 selector / Product factory / container 挿入位置だけを定義する形に整理。
 
 作業:
 
 1. 詳細ページ系を `{ service, scrapeData, createProduct, mountPoint }` の宣言的設定に寄せる。（完了）
-2. 一覧ページ系（DMMBasket / DLsiteCart）の observer + per-item 検索 + リンク注入を共通化する。（着手中）
+2. 一覧ページ系（DMMBasket / DLsiteCart）の observer + per-item 検索 + リンク注入を共通化する。（完了）
 
 注意:
 

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -316,11 +316,12 @@ CI強化:
 - バー描画用 root element の作成・挿入を `BaseContentScript.mountRootElement()` / `mountRootElementAtBodyStart()` に集約し、詳細ページ系 content script の `createElementForBar()` から重複する `div#uniBarRoot` 作成を撤去。
 - 詳細ページ系 content script の mount selector / position / fallback / prepare 処理を `rootElementMountPoint` の宣言的設定へ寄せ、単純な `createElementForBar()` override を撤去。
 - 詳細ページ系 content script を `DetailContentScript<TScrapedData>` に寄せ、`scrapeData()` と `createProduct()` を分離。`publishedAt` の dayjs 変換も基底側に集約。
+- 一覧ページ系（DMMBasket / DLsiteCart）の Scrapbox リンク表示と `ScrapboxPageDto -> 表示リンク` mapping を `cartScrapboxLinks.tsx` に集約。
 
 作業:
 
 1. 詳細ページ系を `{ service, scrapeData, createProduct, mountPoint }` の宣言的設定に寄せる。（完了）
-2. 一覧ページ系（DMMBasket / DLsiteCart）の observer + per-item 検索 + リンク注入を共通化する。
+2. 一覧ページ系（DMMBasket / DLsiteCart）の observer + per-item 検索 + リンク注入を共通化する。（着手中）
 
 注意:
 

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -315,12 +315,12 @@ CI強化:
 - `waitForScrape` / `waitForElement` を `src/contentScript/dom/waitForScrape.ts` に追加し、BFF / SPA で本文が後から描画されるサイトを `waitForDynamicContent` 経由に統一。
 - バー描画用 root element の作成・挿入を `BaseContentScript.mountRootElement()` / `mountRootElementAtBodyStart()` に集約し、詳細ページ系 content script の `createElementForBar()` から重複する `div#uniBarRoot` 作成を撤去。
 - 詳細ページ系 content script の mount selector / position / fallback / prepare 処理を `rootElementMountPoint` の宣言的設定へ寄せ、単純な `createElementForBar()` override を撤去。
+- 詳細ページ系 content script を `DetailContentScript<TScrapedData>` に寄せ、`scrapeData()` と `createProduct()` を分離。`publishedAt` の dayjs 変換も基底側に集約。
 
 作業:
 
-1. 詳細ページ系を `{ service, scrape, createProduct, mountPoint }` の宣言的設定に寄せる。
-2. `scrape()` 内の `ScrapedData -> Product` 変換を createProduct 定義へ寄せる。
-3. 一覧ページ系（DMMBasket / DLsiteCart）の observer + per-item 検索 + リンク注入を共通化する。
+1. 詳細ページ系を `{ service, scrapeData, createProduct, mountPoint }` の宣言的設定に寄せる。（完了）
+2. 一覧ページ系（DMMBasket / DLsiteCart）の observer + per-item 検索 + リンク注入を共通化する。
 
 注意:
 

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -314,11 +314,12 @@ CI強化:
 
 - `waitForScrape` / `waitForElement` を `src/contentScript/dom/waitForScrape.ts` に追加し、BFF / SPA で本文が後から描画されるサイトを `waitForDynamicContent` 経由に統一。
 - バー描画用 root element の作成・挿入を `BaseContentScript.mountRootElement()` / `mountRootElementAtBodyStart()` に集約し、詳細ページ系 content script の `createElementForBar()` から重複する `div#uniBarRoot` 作成を撤去。
+- 詳細ページ系 content script の mount selector / position / fallback / prepare 処理を `rootElementMountPoint` の宣言的設定へ寄せ、単純な `createElementForBar()` override を撤去。
 
 作業:
 
 1. 詳細ページ系を `{ service, scrape, createProduct, mountPoint }` の宣言的設定に寄せる。
-2. `createElementForBar()` のサイト固有 selector を mountPoint 定義へ寄せる。
+2. `scrape()` 内の `ScrapedData -> Product` 変換を createProduct 定義へ寄せる。
 3. 一覧ページ系（DMMBasket / DLsiteCart）の observer + per-item 検索 + リンク注入を共通化する。
 
 注意:

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -1,12 +1,12 @@
 # uni リファクタリング計画（Phase 1 完了後）
 
-> 更新: 2026-06-28 / 最新 `main` (`b481243`, `refactor: unify scraper publishedAt contract (#26)`) を基準に更新。
+> 更新: 2026-06-30 / 最新 `main` (`712885d`, `refactor: unify content script DOM waiting (Phase 4 PR-A) (#31)`) を基準に更新。
 > Phase 1（Product 丸ごと越境の廃止、検索 query DTO 化、null ガード、background の projectName 再読込、port 経路エラー応答）は完了済み。
 > Phase 1.5（検索境界の完全 DTO 化、`sendMessage` 一本化、port 経路廃止）は完了済み。
 > Phase 7a（ビルド/エントリ基盤の方針決定 ADR）は完了済み。WXT を採用方針とし、Phase 5 では自前 generator を作り込まない。
 > Phase 6（フィクスチャテストの導入）は主要対象の実ページ由来 HTML fixture と Small characterization test を追加済み。
 > Phase 3（Scraper 契約の統一）は完了済み。`publishedAt` の `Date | null` 統一、scraped data 型の集約、scraper logging 集約、Amazon publisher parse 修正、Amazon speculative fallback selector 削減を追加済み。
-> Phase 2（Product 責務分離）は完了。`titleForSearch` と Scrapbox placeholder formatter を pure domain function として `src/domain` に抽出し、`createScrapboxBodyString` を storage 非依存の同期 pure メソッド化、全角→半角変換を `src/domain/halfWidth.ts` に集約、各 product class の default format を `{token}` 化して toTemplateVars 経由の1経路に統一済み。次の作業対象は Phase 4。
+> Phase 2（Product 責務分離）は完了。`titleForSearch` と Scrapbox placeholder formatter を pure domain function として `src/domain` に抽出し、`createScrapboxBodyString` を storage 非依存の同期 pure メソッド化、全角→半角変換を `src/domain/halfWidth.ts` に集約、各 product class の default format を `{token}` 化して toTemplateVars 経由の1経路に統一済み。Phase 4（Content Script 共通化）は着手済み。
 > 今後はフル Clean Architecture ではなく、uni の規模に合わせた **DDD-lite + 最小 port 境界** を採用する。
 
 ## 0. 現在地
@@ -154,7 +154,7 @@ hampu と同じ考え方で、方向性チェックをCIに入れる。
 
 **Phase 7a → Phase 6 → Phase 3 → Phase 2 → Phase 4 → Phase 5 → Phase 7b → Phase 8**
 
-Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 は完了済みとして扱う。次の作業対象は Phase 4。
+Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 は完了済みとして扱う。現在の作業対象は Phase 4。
 
 ### Phase 1.5 — 検索境界の完全 DTO 化と sendMessage 一本化（完了）
 
@@ -310,10 +310,15 @@ CI強化:
 
 - 各サイトのエントリを薄くし、DOM待ちとバー描画の重複を減らす。
 
+着手済み:
+
+- `waitForScrape` / `waitForElement` を `src/contentScript/dom/waitForScrape.ts` に追加し、BFF / SPA で本文が後から描画されるサイトを `waitForDynamicContent` 経由に統一。
+- バー描画用 root element の作成・挿入を `BaseContentScript.mountRootElement()` / `mountRootElementAtBodyStart()` に集約し、詳細ページ系 content script の `createElementForBar()` から重複する `div#uniBarRoot` 作成を撤去。
+
 作業:
 
-1. `waitForElement` / `waitForSelector` を共通化。
-2. 詳細ページ系を `{ service, scrape, createProduct, mountPoint }` の宣言的設定に寄せる。
+1. 詳細ページ系を `{ service, scrape, createProduct, mountPoint }` の宣言的設定に寄せる。
+2. `createElementForBar()` のサイト固有 selector を mountPoint 定義へ寄せる。
 3. 一覧ページ系（DMMBasket / DLsiteCart）の observer + per-item 検索 + リンク注入を共通化する。
 
 注意:

--- a/src/__tests__/small/contentScript/base-content-script-message.test.ts
+++ b/src/__tests__/small/contentScript/base-content-script-message.test.ts
@@ -31,6 +31,30 @@ class TestContentScript extends BaseContentScript {
   }
 }
 
+class MountTestContentScript extends BaseContentScript {
+  protected readonly SERVICE = AcceptedService.fanza;
+
+  protected scrape(): Product | null {
+    return null;
+  }
+
+  protected createElementForBar(): void {
+    // root element mount helper の単体検証用
+  }
+
+  public mountAppend(target: Element): HTMLDivElement {
+    return this.mountRootElement(target);
+  }
+
+  public mountAfterEnd(target: Element): HTMLDivElement {
+    return this.mountRootElement(target, "afterend");
+  }
+
+  public mountAtBodyStart(): HTMLDivElement {
+    return this.mountRootElementAtBodyStart();
+  }
+}
+
 const makeProduct = (title: string): Product => {
   return Doujinshi.make(
     AcceptedService.fanza,
@@ -88,6 +112,60 @@ test("検索エラーを受け取った場合はバーを描画しない", async
   await Promise.resolve();
 
   expect(script.createdBars).toBe(0);
+});
+
+describe("root element mounting", () => {
+  let originalDocument: unknown;
+
+  beforeEach(() => {
+    originalDocument = (globalThis as { document?: Document }).document;
+  });
+
+  afterEach(() => {
+    (globalThis as { document?: unknown }).document = originalDocument;
+  });
+
+  const setGlobalDocument = (document: Document) => {
+    (globalThis as { document?: Document }).document = document;
+  };
+
+  test("指定した要素の末尾にuni bar rootを追加する", () => {
+    const { document } = parseHTML(
+      '<!DOCTYPE html><html><body><header id="header"></header></body></html>',
+    );
+    setGlobalDocument(document as unknown as Document);
+
+    const header = document.getElementById("header");
+    const root = new MountTestContentScript().mountAppend(header);
+
+    expect(root.id).toBe("uniBarRoot");
+    expect(header.lastElementChild).toBe(root);
+  });
+
+  test("指定した要素の直後にuni bar rootを追加する", () => {
+    const { document } = parseHTML(
+      '<!DOCTYPE html><html><body><header id="header"></header><main></main></body></html>',
+    );
+    setGlobalDocument(document as unknown as Document);
+
+    const header = document.getElementById("header");
+    const root = new MountTestContentScript().mountAfterEnd(header);
+
+    expect(root.id).toBe("uniBarRoot");
+    expect(header.nextElementSibling).toBe(root);
+  });
+
+  test("bodyの先頭にuni bar rootを追加する", () => {
+    const { document } = parseHTML(
+      '<!DOCTYPE html><html><body><main id="first"></main></body></html>',
+    );
+    setGlobalDocument(document as unknown as Document);
+
+    const root = new MountTestContentScript().mountAtBodyStart();
+
+    expect(root.id).toBe("uniBarRoot");
+    expect(document.body.firstElementChild).toBe(root);
+  });
 });
 
 describe("動的描画サイト (waitForDynamicContent)", () => {

--- a/src/__tests__/small/contentScript/base-content-script-message.test.ts
+++ b/src/__tests__/small/contentScript/base-content-script-message.test.ts
@@ -55,6 +55,22 @@ class MountTestContentScript extends BaseContentScript {
   }
 }
 
+class DeclarativeMountTestContentScript extends BaseContentScript {
+  protected readonly SERVICE = AcceptedService.fanza;
+  protected readonly rootElementMountPoint = {
+    target: "#header",
+    position: "afterend" as const,
+  };
+
+  protected scrape(): Product | null {
+    return null;
+  }
+
+  public mountFromConfig(): void {
+    this.createElementForBar();
+  }
+}
+
 const makeProduct = (title: string): Product => {
   return Doujinshi.make(
     AcceptedService.fanza,
@@ -165,6 +181,18 @@ describe("root element mounting", () => {
 
     expect(root.id).toBe("uniBarRoot");
     expect(document.body.firstElementChild).toBe(root);
+  });
+
+  test("rootElementMountPointの設定でuni bar rootを追加する", () => {
+    const { document } = parseHTML(
+      '<!DOCTYPE html><html><body><header id="header"></header><main></main></body></html>',
+    );
+    setGlobalDocument(document as unknown as Document);
+
+    new DeclarativeMountTestContentScript().mountFromConfig();
+
+    const header = document.getElementById("header");
+    expect(header.nextElementSibling?.id).toBe("uniBarRoot");
   });
 });
 

--- a/src/__tests__/small/contentScript/base-content-script-message.test.ts
+++ b/src/__tests__/small/contentScript/base-content-script-message.test.ts
@@ -9,6 +9,7 @@ import {
 import { parseHTML } from "linkedom";
 import browser from "webextension-polyfill";
 import { BaseContentScript } from "../../../contentScript/BaseContentScript";
+import { DetailContentScript } from "../../../contentScript/DetailContentScript";
 import { AcceptedService } from "../../../constant";
 import Doujinshi from "../../../Doujinshi";
 import Product from "../../../Product";
@@ -71,6 +72,23 @@ class DeclarativeMountTestContentScript extends BaseContentScript {
   }
 }
 
+class DetailTestContentScript extends DetailContentScript<{ title: string }> {
+  protected readonly SERVICE = AcceptedService.fanza;
+  protected readonly rootElementMountPoint = { target: "body" };
+
+  constructor(private readonly scrapedData: { title: string } | null) {
+    super();
+  }
+
+  protected scrapeData(): { title: string } | null {
+    return this.scrapedData;
+  }
+
+  protected createProduct(scrapedData: { title: string }): Product {
+    return makeProduct(scrapedData.title);
+  }
+}
+
 const makeProduct = (title: string): Product => {
   return Doujinshi.make(
     AcceptedService.fanza,
@@ -128,6 +146,15 @@ test("検索エラーを受け取った場合はバーを描画しない", async
   await Promise.resolve();
 
   expect(script.createdBars).toBe(0);
+});
+
+test("DetailContentScriptはscraped dataからProductを作って検索する", () => {
+  new DetailTestContentScript({ title: "詳細ページ(2)" }).execute();
+
+  expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+    action: SearchBibliographyAction,
+    query: "詳細ページ 2",
+  });
 });
 
 describe("root element mounting", () => {

--- a/src/__tests__/small/contentScript/cart-scrapbox-checker.test.ts
+++ b/src/__tests__/small/contentScript/cart-scrapbox-checker.test.ts
@@ -1,0 +1,171 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from "@jest/globals";
+import { parseHTML } from "linkedom";
+import browser from "webextension-polyfill";
+import { mountCartScrapboxChecker } from "../../../contentScript/CartScrapboxChecker";
+import { AcceptedService } from "../../../constant";
+import Doujinshi from "../../../Doujinshi";
+import { SearchBibliographyAction } from "../../../scrapbox/searchDtos";
+
+const waitForEffects = async (ms = 20) => {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+};
+
+const waitUntil = async (predicate: () => boolean) => {
+  for (let i = 0; i < 10; i += 1) {
+    if (predicate()) {
+      return;
+    }
+    await waitForEffects(20);
+  }
+};
+
+const sendMessageMock = () => {
+  return browser.runtime.sendMessage as jest.MockedFunction<
+    (message?: unknown) => Promise<unknown>
+  >;
+};
+
+describe("CartScrapboxChecker", () => {
+  let originalDocument: unknown;
+  let originalWindow: unknown;
+  let originalNode: unknown;
+  let originalMutationObserver: unknown;
+  let originalChrome: unknown;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, "log").mockImplementation(() => undefined);
+    originalDocument = (globalThis as { document?: Document }).document;
+    originalWindow = (globalThis as { window?: Window }).window;
+    originalNode = (globalThis as { Node?: typeof Node }).Node;
+    originalMutationObserver = (
+      globalThis as { MutationObserver?: typeof MutationObserver }
+    ).MutationObserver;
+    originalChrome = (globalThis as { chrome?: unknown }).chrome;
+
+    sendMessageMock().mockResolvedValue({
+      status: "ok",
+      projectName: "proj",
+      searchResult: {
+        count: 1,
+        pages: [
+          {
+            title: "既存ページ",
+            pageUrl: "https://scrapbox.io/proj/%E6%97%A2%E5%AD%98",
+          },
+        ],
+      },
+    });
+
+    (globalThis as { chrome?: unknown }).chrome = {
+      storage: {
+        sync: {
+          get: jest.fn((_keys, callback: (result: unknown) => void) => {
+            callback({ projectName: "proj" });
+          }),
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as { document?: unknown }).document = originalDocument;
+    (globalThis as { window?: unknown }).window = originalWindow;
+    (globalThis as { Node?: unknown }).Node = originalNode;
+    (globalThis as { MutationObserver?: unknown }).MutationObserver =
+      originalMutationObserver;
+    (globalThis as { chrome?: unknown }).chrome = originalChrome;
+    jest.restoreAllMocks();
+  });
+
+  const setGlobalDom = (html: string) => {
+    const { document, window } = parseHTML(html);
+    (globalThis as { document?: Document }).document =
+      document as unknown as Document;
+    (globalThis as { window?: Window }).window = window as unknown as Window;
+    (globalThis as { Node?: typeof Node }).Node = window.Node;
+    (globalThis as { MutationObserver?: typeof MutationObserver }).MutationObserver =
+      window.MutationObserver;
+    return document;
+  };
+
+  const mountChecker = () => {
+    mountCartScrapboxChecker("cart-checker-root", {
+      logPrefix: "[Cart Test]",
+      missingProjectNameMessage: "[Cart Test] missing project",
+      observerTargetSelector: "ul.cart",
+      observerTargetDescription: "ul.cart",
+      itemSelector: "li.item",
+      createProduct: (item) => {
+        const titleAnchor = item.querySelector<HTMLAnchorElement>("a.title");
+        const title = titleAnchor?.textContent?.trim();
+        if (!title) {
+          return null;
+        }
+
+        return Doujinshi.make(
+          AcceptedService.dmmDoujinBasket,
+          title,
+          [],
+          titleAnchor?.href || window.location.href,
+          null,
+          "circle",
+          null,
+        );
+      },
+      insertLinksContainer: (item, linksContainer) => {
+        item.querySelector(".links-anchor")?.appendChild(linksContainer);
+      },
+    });
+  };
+
+  test("初期表示のcart itemを検索し、指定位置へScrapboxリンクを描画する", async () => {
+    const document = setGlobalDom(
+      '<!DOCTYPE html><html><body><ul class="cart"><li class="item"><a class="title" href="https://example.com/item">タイトル(1)</a><div class="links-anchor"></div></li></ul></body></html>',
+    );
+
+    mountChecker();
+    await waitUntil(() => sendMessageMock().mock.calls.length > 0);
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      action: SearchBibliographyAction,
+      query: "タイトル 1",
+    });
+    const linksContainer = document.querySelector(".scrapbox-links-container");
+    expect(linksContainer?.parentElement?.className).toBe("links-anchor");
+    expect(linksContainer?.textContent).toContain("もう買ってるかも:");
+    expect(
+      linksContainer?.querySelector<HTMLAnchorElement>("a")?.href,
+    ).toContain("https://scrapbox.io/proj/");
+  });
+
+  test("後から追加されたcart itemをMutationObserver経由で検索する", async () => {
+    const document = setGlobalDom(
+      '<!DOCTYPE html><html><body><ul class="cart"></ul></body></html>',
+    );
+
+    mountChecker();
+    await waitForEffects(50);
+    expect(browser.runtime.sendMessage).not.toHaveBeenCalled();
+
+    const item = document.createElement("li");
+    item.className = "item";
+    item.innerHTML =
+      '<a class="title" href="https://example.com/new">追加タイトル</a><div class="links-anchor"></div>';
+    document.querySelector("ul.cart")?.appendChild(item);
+    await waitUntil(() => sendMessageMock().mock.calls.length > 0);
+
+    expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
+      action: SearchBibliographyAction,
+      query: "追加タイトル",
+    });
+    expect(item.querySelector(".scrapbox-links-container")).not.toBeNull();
+  });
+});

--- a/src/contentScript/Amazon.tsx
+++ b/src/contentScript/Amazon.tsx
@@ -17,10 +17,8 @@ class Amazon extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    const rootElement = this.createRootElement();
-
     const header = document.getElementById("navbar");
-    header.appendChild(rootElement);
+    this.mountRootElement(header);
   }
 
   /**

--- a/src/contentScript/Amazon.tsx
+++ b/src/contentScript/Amazon.tsx
@@ -2,32 +2,22 @@ import Book from "../Book";
 import * as React from "react";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import { scrapeAmazonData } from "../scraping/amazon-scraper";
+import { AmazonScrapedData } from "../scraping/types";
 
 /**
  * Amazonのページを開いたときに実行される
  */
-class Amazon extends BaseContentScript {
+class Amazon extends DetailContentScript<AmazonScrapedData> {
   protected readonly SERVICE = AcceptedService.amazon;
   protected readonly rootElementMountPoint = { target: "#navbar" };
 
-  /**
-   * 必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Book {
-    const scrapedData = scrapeAmazonData(document);
+  protected scrapeData(): AmazonScrapedData | null {
+    return scrapeAmazonData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
-    const publishedAt = scrapedData.publishedAt
-      ? dayjs(scrapedData.publishedAt)
-      : null;
-
+  protected createProduct(scrapedData: AmazonScrapedData): Book {
     // background scriptに送る
     return Book.make(
       this.SERVICE,
@@ -36,7 +26,7 @@ class Amazon extends BaseContentScript {
       scrapedData.url,
       scrapedData.publisher,
       null, // label
-      publishedAt,
+      this.publishedAt(scrapedData.publishedAt),
     );
   }
 }

--- a/src/contentScript/Amazon.tsx
+++ b/src/contentScript/Amazon.tsx
@@ -11,15 +11,7 @@ import { scrapeAmazonData } from "../scraping/amazon-scraper";
  */
 class Amazon extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.amazon;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    const header = document.getElementById("navbar");
-    this.mountRootElement(header);
-  }
+  protected readonly rootElementMountPoint = { target: "#navbar" };
 
   /**
    * 必要な情報をスクレイピングする

--- a/src/contentScript/BaseContentScript.tsx
+++ b/src/contentScript/BaseContentScript.tsx
@@ -13,6 +13,8 @@ import {
 } from "../scrapbox/searchDtos";
 import { waitForScrape } from "./dom/waitForScrape";
 
+type RootElementMountPosition = "append" | "prepend" | "afterend";
+
 /**
  * Content Scriptに必要な処理を集約したクラス
  */
@@ -162,5 +164,29 @@ export abstract class BaseContentScript {
     const divElement = document.createElement("div");
     divElement.id = this.ROOT_ELEM;
     return divElement;
+  }
+
+  protected mountRootElement(
+    target: Element,
+    position: RootElementMountPosition = "append",
+  ): HTMLDivElement {
+    const rootElement = this.createRootElement();
+
+    switch (position) {
+      case "prepend":
+        target.insertBefore(rootElement, target.firstChild);
+        break;
+      case "afterend":
+        target.insertAdjacentElement("afterend", rootElement);
+        break;
+      default:
+        target.appendChild(rootElement);
+    }
+
+    return rootElement;
+  }
+
+  protected mountRootElementAtBodyStart(): HTMLDivElement {
+    return this.mountRootElement(document.body, "prepend");
   }
 }

--- a/src/contentScript/BaseContentScript.tsx
+++ b/src/contentScript/BaseContentScript.tsx
@@ -14,6 +14,12 @@ import {
 import { waitForScrape } from "./dom/waitForScrape";
 
 type RootElementMountPosition = "append" | "prepend" | "afterend";
+type RootElementMountPoint = {
+  target: string | (() => Element | null);
+  position?: RootElementMountPosition;
+  fallback?: "bodyStart";
+  prepareTarget?: (target: Element) => void;
+};
 
 /**
  * Content Scriptに必要な処理を集約したクラス
@@ -32,6 +38,8 @@ export abstract class BaseContentScript {
   /** 動的描画を待つ場合のタイムアウト（ミリ秒）。 */
   protected readonly scrapeTimeoutMs: number = 10000;
 
+  protected readonly rootElementMountPoint?: RootElementMountPoint;
+
   /**
    * 開いたページから必要な情報をスクレイピングする
    * サービスのHTMLに依存する
@@ -39,12 +47,13 @@ export abstract class BaseContentScript {
    */
   protected abstract scrape(): Product | null;
 
-  /**
-   * 開いたページの上部のいい感じの要素を開発ツールで調べて指定する
-   * サービスのHTMLに依存する
-   * @protected
-   */
-  protected abstract createElementForBar(): void;
+  protected createElementForBar(): void {
+    if (!this.rootElementMountPoint) {
+      throw new Error("rootElementMountPoint is not configured");
+    }
+
+    this.mountRootElementAt(this.rootElementMountPoint);
+  }
 
   execute() {
     // 静的サイトと、本文が即時に存在する一般的なケースはここで完結する。
@@ -188,5 +197,25 @@ export abstract class BaseContentScript {
 
   protected mountRootElementAtBodyStart(): HTMLDivElement {
     return this.mountRootElement(document.body, "prepend");
+  }
+
+  protected mountRootElementAt(
+    mountPoint: RootElementMountPoint,
+  ): HTMLDivElement {
+    const target =
+      typeof mountPoint.target === "string"
+        ? document.querySelector(mountPoint.target)
+        : mountPoint.target();
+
+    if (target) {
+      mountPoint.prepareTarget?.(target);
+      return this.mountRootElement(target, mountPoint.position);
+    }
+
+    if (mountPoint.fallback === "bodyStart") {
+      return this.mountRootElementAtBodyStart();
+    }
+
+    throw new Error("root element mount target was not found");
   }
 }

--- a/src/contentScript/BookWalker.tsx
+++ b/src/contentScript/BookWalker.tsx
@@ -18,8 +18,6 @@ class BookWalker extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    const rootElement = this.createRootElement();
-
     // 複数の候補を試す
     let targetElement =
       document.getElementsByClassName("header")[0] ||
@@ -29,9 +27,9 @@ class BookWalker extends BaseContentScript {
 
     if (targetElement === document.body) {
       // bodyの最初の子要素として挿入
-      document.body.insertBefore(rootElement, document.body.firstChild);
+      this.mountRootElementAtBodyStart();
     } else {
-      targetElement.appendChild(rootElement);
+      this.mountRootElement(targetElement);
     }
   }
 

--- a/src/contentScript/BookWalker.tsx
+++ b/src/contentScript/BookWalker.tsx
@@ -2,15 +2,15 @@ import Book from "../Book";
 import * as React from "react";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import { scrapeBookWalkerData } from "../scraping/bookwalker-scraper";
+import { BookWalkerScrapedData } from "../scraping/types";
 
 /**
  * Bookwalkerのページを開いたときに実行される
  * https://bookwalker.jp/dea73feaf6-9f21-4c46-ac85-991153a0b71b/
  */
-class BookWalker extends BaseContentScript {
+class BookWalker extends DetailContentScript<BookWalkerScrapedData> {
   protected readonly SERVICE = AcceptedService.bookWalker;
   protected readonly rootElementMountPoint = {
     target: () =>
@@ -20,21 +20,11 @@ class BookWalker extends BaseContentScript {
     fallback: "bodyStart" as const,
   };
 
-  /**
-   * 必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Book {
-    const scrapedData = scrapeBookWalkerData(document);
+  protected scrapeData(): BookWalkerScrapedData | null {
+    return scrapeBookWalkerData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
-    const publishedAt = scrapedData.publishedAt
-      ? dayjs(scrapedData.publishedAt)
-      : null;
-
+  protected createProduct(scrapedData: BookWalkerScrapedData): Book {
     // background scriptに送る
     return Book.make(
       this.SERVICE,
@@ -43,7 +33,7 @@ class BookWalker extends BaseContentScript {
       scrapedData.url,
       scrapedData.publisher,
       scrapedData.label,
-      publishedAt,
+      this.publishedAt(scrapedData.publishedAt),
     );
   }
 

--- a/src/contentScript/BookWalker.tsx
+++ b/src/contentScript/BookWalker.tsx
@@ -12,26 +12,13 @@ import { scrapeBookWalkerData } from "../scraping/bookwalker-scraper";
  */
 class BookWalker extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.bookWalker;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    // 複数の候補を試す
-    let targetElement =
+  protected readonly rootElementMountPoint = {
+    target: () =>
       document.getElementsByClassName("header")[0] ||
       document.querySelector("header") ||
-      document.querySelector("nav") ||
-      document.body;
-
-    if (targetElement === document.body) {
-      // bodyの最初の子要素として挿入
-      this.mountRootElementAtBodyStart();
-    } else {
-      this.mountRootElement(targetElement);
-    }
-  }
+      document.querySelector("nav"),
+    fallback: "bodyStart" as const,
+  };
 
   /**
    * 必要な情報をスクレイピングする

--- a/src/contentScript/CartScrapboxChecker.tsx
+++ b/src/contentScript/CartScrapboxChecker.tsx
@@ -1,0 +1,210 @@
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+import { StorageKeyProjectName } from "../chromeApi";
+import Product from "../Product";
+import ScrapboxApiClient from "../scrapbox/scrapboxApi";
+import {
+  CartScrapboxLinksDisplay,
+  toCartScrapboxLinks,
+} from "./cartScrapboxLinks";
+
+const LinksContainerClassName = "scrapbox-links-container";
+
+export type CartScrapboxCheckerConfig = {
+  logPrefix: string;
+  missingProjectNameMessage: string;
+  observerTargetSelector: string;
+  observerTargetDescription: string;
+  itemSelector: string;
+  initialItemSelector?: string;
+  initialItemFilter?: (item: HTMLElement) => boolean;
+  createProduct: (item: HTMLElement) => Product | null;
+  insertLinksContainer: (
+    item: HTMLElement,
+    linksContainer: HTMLElement,
+  ) => void;
+  pollRetries?: number;
+  pollIntervalMs?: number;
+};
+
+type CartScrapboxCheckerProps = {
+  config: CartScrapboxCheckerConfig;
+};
+
+const createLinksContainerId = (title: string): string => {
+  return `scrapbox-links-${encodeURIComponent(title.substring(0, 10))}-${Math.random().toString(36).substring(2, 7)}`;
+};
+
+const CartScrapboxChecker: React.FC<CartScrapboxCheckerProps> = ({
+  config,
+}) => {
+  const [projectName, setProjectName] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    chrome.storage.sync.get([StorageKeyProjectName], (result) => {
+      const storedProjectName = result[StorageKeyProjectName];
+      if (typeof storedProjectName === "string" && storedProjectName.trim()) {
+        setProjectName(storedProjectName);
+      } else {
+        console.warn(config.missingProjectNameMessage);
+      }
+    });
+  }, [config]);
+
+  const processCartItem = React.useCallback(
+    async (item: HTMLElement, processedItems: WeakSet<HTMLElement>) => {
+      if (processedItems.has(item) || !projectName) {
+        return;
+      }
+      processedItems.add(item);
+
+      const product = config.createProduct(item);
+      if (!product) {
+        return;
+      }
+
+      console.log(`${config.logPrefix} Checking: ${product.title}`);
+      const apiClient = new ScrapboxApiClient();
+      try {
+        const searchResult = await apiClient.search({ product });
+        console.log(
+          `${config.logPrefix} searchResult for "${product.title}":`,
+          searchResult,
+        );
+
+        if (
+          searchResult &&
+          searchResult.count > 0 &&
+          searchResult.pages &&
+          searchResult.pages.length > 0
+        ) {
+          console.log(
+            `${config.logPrefix} Found in Scrapbox: ${product.title}. Count: ${searchResult.count}, Pages:`,
+            searchResult.pages,
+          );
+          const existingLinksContainer = item.querySelector<HTMLElement>(
+            `.${LinksContainerClassName}`,
+          );
+          existingLinksContainer?.remove();
+
+          const linksContainer = document.createElement("div");
+          linksContainer.id = createLinksContainerId(product.title);
+          linksContainer.className = LinksContainerClassName;
+          config.insertLinksContainer(item, linksContainer);
+
+          const root = createRoot(linksContainer);
+          root.render(
+            <CartScrapboxLinksDisplay
+              existPages={toCartScrapboxLinks(searchResult.pages)}
+            />,
+          );
+        } else {
+          console.log(
+            `${config.logPrefix} Not found in Scrapbox: ${product.title}`,
+          );
+        }
+      } catch (error) {
+        console.error(`${config.logPrefix} Error searching Scrapbox:`, error);
+      }
+    },
+    [config, projectName],
+  );
+
+  React.useEffect(() => {
+    if (!projectName) return;
+
+    const processedItems = new WeakSet<HTMLElement>();
+
+    const processMatchingItems = (elementNode: HTMLElement) => {
+      if (elementNode.matches(config.itemSelector)) {
+        void processCartItem(elementNode, processedItems);
+      }
+      elementNode
+        .querySelectorAll<HTMLElement>(config.itemSelector)
+        .forEach((item) => {
+          void processCartItem(item, processedItems);
+        });
+    };
+
+    const handleMutations = (mutationsList: MutationRecord[]) => {
+      for (const mutation of mutationsList) {
+        if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
+          mutation.addedNodes.forEach((node) => {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+              processMatchingItems(node as HTMLElement);
+            }
+          });
+        }
+      }
+    };
+
+    let observer: MutationObserver | null = null;
+    let cancelled = false;
+
+    const setupObserver = (targetNode: HTMLElement) => {
+      observer = new MutationObserver(handleMutations);
+      observer.observe(targetNode, { childList: true, subtree: true });
+      const initialItems = document.querySelectorAll<HTMLElement>(
+        config.initialItemSelector ?? config.itemSelector,
+      );
+      initialItems.forEach((item) => {
+        if (!config.initialItemFilter || config.initialItemFilter(item)) {
+          void processCartItem(item, processedItems);
+        }
+      });
+    };
+
+    const pollForTarget = (
+      retries = config.pollRetries ?? 10,
+      interval = config.pollIntervalMs ?? 500,
+    ) => {
+      if (cancelled) return;
+
+      const targetNode = document.querySelector<HTMLElement>(
+        config.observerTargetSelector,
+      );
+      if (targetNode) {
+        console.log(
+          `${config.logPrefix} Target node '${config.observerTargetDescription}' found. Setting up MutationObserver.`,
+        );
+        setupObserver(targetNode);
+      } else if (retries > 0) {
+        console.log(
+          `${config.logPrefix} '${config.observerTargetDescription}' not found. Retrying in ${interval}ms... (${retries} retries left)`,
+        );
+        setTimeout(() => pollForTarget(retries - 1, interval), interval);
+      } else {
+        console.error(
+          `${config.logPrefix} Target node '${config.observerTargetDescription}' not found after multiple retries. Observer not set up.`,
+        );
+      }
+    };
+
+    pollForTarget();
+
+    return () => {
+      cancelled = true;
+      observer?.disconnect();
+      document
+        .querySelectorAll(`.${LinksContainerClassName}`)
+        .forEach((el) => el.remove());
+    };
+  }, [config, processCartItem, projectName]);
+
+  return null;
+};
+
+export function mountCartScrapboxChecker(
+  rootElementId: string,
+  config: CartScrapboxCheckerConfig,
+): void {
+  if (!document.getElementById(rootElementId)) {
+    const rootElement = document.createElement("div");
+    rootElement.id = rootElementId;
+    document.body.appendChild(rootElement);
+    const root = createRoot(rootElement);
+    root.render(<CartScrapboxChecker config={config} />);
+  } else {
+    console.log(`${config.logPrefix} Root element already exists.`);
+  }
+}

--- a/src/contentScript/DLsiteBooks.tsx
+++ b/src/contentScript/DLsiteBooks.tsx
@@ -12,15 +12,7 @@ import { scrapeDLsiteBooksData } from "../scraping/dlsite-books-scraper";
  */
 class DLsiteBooks extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.dlsite;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    const header = document.getElementById("header");
-    this.mountRootElement(header);
-  }
+  protected readonly rootElementMountPoint = { target: "#header" };
 
   /**
    * 必要な情報をスクレイピングする

--- a/src/contentScript/DLsiteBooks.tsx
+++ b/src/contentScript/DLsiteBooks.tsx
@@ -18,10 +18,8 @@ class DLsiteBooks extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    const divElement = document.createElement("div");
-    divElement.id = this.ROOT_ELEM;
     const header = document.getElementById("header");
-    header.appendChild(divElement);
+    this.mountRootElement(header);
   }
 
   /**

--- a/src/contentScript/DLsiteBooks.tsx
+++ b/src/contentScript/DLsiteBooks.tsx
@@ -2,29 +2,23 @@ import Book from "../Book";
 import * as React from "react";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import { scrapeDLsiteBooksData } from "../scraping/dlsite-books-scraper";
+import { DLsiteBooksScrapedData } from "../scraping/types";
 
 /**
  * DLSite booksのページを開いたときに実行される
  * https://www.dlsite.com/books/work/=/product_id/BJ183632.html
  */
-class DLsiteBooks extends BaseContentScript {
+class DLsiteBooks extends DetailContentScript<DLsiteBooksScrapedData> {
   protected readonly SERVICE = AcceptedService.dlsite;
   protected readonly rootElementMountPoint = { target: "#header" };
 
-  /**
-   * 必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Book {
-    const scrapedData = scrapeDLsiteBooksData(document);
+  protected scrapeData(): DLsiteBooksScrapedData | null {
+    return scrapeDLsiteBooksData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
+  protected createProduct(scrapedData: DLsiteBooksScrapedData): Book {
     // background scriptに送る
     return Book.make(
       AcceptedService.dlsite,
@@ -33,7 +27,7 @@ class DLsiteBooks extends BaseContentScript {
       scrapedData.url,
       scrapedData.publisher,
       scrapedData.label,
-      scrapedData.publishedAt ? dayjs(scrapedData.publishedAt) : null,
+      this.publishedAt(scrapedData.publishedAt),
     );
   }
 }

--- a/src/contentScript/DLsiteCart.tsx
+++ b/src/contentScript/DLsiteCart.tsx
@@ -1,205 +1,45 @@
-import * as React from "react";
-import { createRoot } from "react-dom/client";
-import ScrapboxApiClient from "../scrapbox/scrapboxApi";
-import DLsiteProduct from "../DLsiteProduct"; // Changed import
+import DLsiteProduct from "../DLsiteProduct";
 import { AcceptedService } from "../constant";
-import { StorageKeyProjectName } from "../chromeApi";
 import {
-  CartScrapboxLinksDisplay,
-  toCartScrapboxLinks,
-} from "./cartScrapboxLinks";
+  CartScrapboxCheckerConfig,
+  mountCartScrapboxChecker,
+} from "./CartScrapboxChecker";
 
-const DLsiteCartChecker = () => {
-  const [projectName, setProjectName] = React.useState<string | null>(null);
+const DLsiteCartCheckerConfig: CartScrapboxCheckerConfig = {
+  logPrefix: "[DLsite Cart Checker]",
+  missingProjectNameMessage:
+    "[DLsite Cart Checker] Scrapbox project name is not set. Please set it in the extension options.",
+  observerTargetSelector: ".payment_cart_list ul.cart_list",
+  observerTargetDescription: ".payment_cart_list ul.cart_list",
+  itemSelector: "li.cart_list_item",
+  initialItemSelector: "div#cart_wrapper li.cart_list_item._cart_items",
+  initialItemFilter: (item) => item.offsetParent !== null,
+  createProduct: (item) => {
+    const titleAnchor = item.querySelector<HTMLAnchorElement>(".work_name > a");
+    const title = titleAnchor?.innerText.trim();
+    if (!title) {
+      return null;
+    }
 
-  React.useEffect(() => {
-    chrome.storage.sync.get([StorageKeyProjectName], (result) => {
-      const storedProjectName = result[StorageKeyProjectName];
-      if (typeof storedProjectName === "string" && storedProjectName.trim()) {
-        setProjectName(storedProjectName);
-      } else {
-        console.warn(
-          "[DLsite Cart Checker] Scrapbox project name is not set. Please set it in the extension options.",
-        );
-      }
-    });
-  }, []);
+    const makerName = item
+      .querySelector<HTMLAnchorElement>(".maker_name > a")
+      ?.innerText.trim();
 
-  const processCartItem = React.useCallback(
-    async (
-      item: HTMLElement,
-      currentProjectName: string,
-      processedItems: WeakSet<HTMLElement>,
-    ) => {
-      if (processedItems.has(item) || !currentProjectName) {
-        return;
-      }
-      processedItems.add(item);
-
-      const titleAnchor =
-        item.querySelector<HTMLAnchorElement>(".work_name > a");
-      const title = titleAnchor?.innerText.trim();
-      const itemUrl = titleAnchor?.href;
-      const makerName = item
-        .querySelector<HTMLAnchorElement>(".maker_name > a")
-        ?.innerText.trim();
-
-      if (title) {
-        console.log(`[DLsite Cart Checker] Checking: ${title}`);
-        const apiClient = new ScrapboxApiClient();
-        try {
-          const product = new DLsiteProduct(
-            AcceptedService.dlsite,
-            title,
-            makerName ? [makerName] : [],
-            itemUrl || window.location.href,
-          );
-
-          const searchResult = await apiClient.search({ product });
-          console.log(
-            `[DLsite Cart Checker] searchResult for "${title}":`,
-            searchResult,
-          );
-
-          if (
-            searchResult &&
-            searchResult.count > 0 &&
-            searchResult.pages &&
-            searchResult.pages.length > 0
-          ) {
-            console.log(
-              `[DLsite Cart Checker] Found in Scrapbox: ${title}. Count: ${searchResult.count}, Pages:`,
-              searchResult.pages,
-            );
-            const linksContainerId = `scrapbox-links-${encodeURIComponent(title.substring(0, 10))}-${Math.random().toString(36).substring(2, 7)}`;
-            let linksContainer = item.querySelector<HTMLElement>(
-              `.scrapbox-links-container`,
-            );
-
-            if (linksContainer) {
-              linksContainer.remove();
-            }
-
-            linksContainer = document.createElement("div");
-            linksContainer.id = linksContainerId;
-            linksContainer.className = "scrapbox-links-container";
-
-            const workContentElement =
-              item.querySelector<HTMLElement>(".work_content");
-            if (workContentElement) {
-              workContentElement.appendChild(linksContainer);
-            } else {
-              // Fallback if .work_content is not found
-              item.appendChild(linksContainer);
-            }
-
-            const root = createRoot(linksContainer);
-            const existPages = toCartScrapboxLinks(searchResult.pages);
-
-            root.render(<CartScrapboxLinksDisplay existPages={existPages} />);
-          } else {
-            console.log(
-              `[DLsite Cart Checker] Not found in Scrapbox: ${title}`,
-            );
-          }
-        } catch (error) {
-          console.error(
-            "[DLsite Cart Checker] Error searching Scrapbox:",
-            error,
-          );
-        }
-      }
-    },
-    [],
-  );
-
-  React.useEffect(() => {
-    if (!projectName) return;
-
-    const processedItems = new WeakSet<HTMLElement>();
-
-    const handleMutations = (mutationsList: MutationRecord[]) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
-          mutation.addedNodes.forEach((node) => {
-            if (node.nodeType === Node.ELEMENT_NODE) {
-              const elementNode = node as HTMLElement;
-              if (
-                elementNode.matches &&
-                elementNode.matches("li.cart_list_item")
-              ) {
-                processCartItem(elementNode, projectName, processedItems);
-              }
-              elementNode
-                .querySelectorAll<HTMLElement>("li.cart_list_item")
-                .forEach((item) => {
-                  processCartItem(item, projectName, processedItems);
-                });
-            }
-          });
-        }
-      }
-    };
-
-    let observer: MutationObserver | null = null;
-
-    const setupObserver = (targetNode: HTMLElement) => {
-      observer = new MutationObserver(handleMutations);
-      observer.observe(targetNode, { childList: true, subtree: true });
-      const initialItems = document.querySelectorAll<HTMLElement>(
-        "div#cart_wrapper li.cart_list_item._cart_items", // More specific selector for initial items
-      );
-      initialItems.forEach((item) => {
-        // Ensure we don't process items that are marked as removed (display:none)
-        if (item.offsetParent !== null) {
-          // Check if the element is visible
-          processCartItem(item, projectName, processedItems);
-        }
-      });
-    };
-
-    const pollForCartList = (retries = 10, interval = 500) => {
-      const targetNode = document.querySelector<HTMLElement>(
-        ".payment_cart_list ul.cart_list",
-      );
-      if (targetNode) {
-        console.log(
-          "[DLsite Cart Checker] Target node '.payment_cart_list ul.cart_list' found. Setting up MutationObserver.",
-        );
-        setupObserver(targetNode);
-      } else if (retries > 0) {
-        console.log(
-          `[DLsite Cart Checker] '.payment_cart_list ul.cart_list' not found. Retrying in ${interval}ms... (${retries} retries left)`,
-        );
-        setTimeout(() => pollForCartList(retries - 1, interval), interval);
-      } else {
-        console.error(
-          "[DLsite Cart Checker] Target node '.payment_cart_list ul.cart_list' not found after multiple retries. Observer not set up.",
-        );
-      }
-    };
-
-    pollForCartList();
-
-    return () => {
-      if (observer) {
-        observer.disconnect();
-      }
-      document
-        .querySelectorAll(".scrapbox-links-container")
-        .forEach((el) => el.remove());
-    };
-  }, [projectName, processCartItem]);
-
-  return null;
+    return new DLsiteProduct(
+      AcceptedService.dlsite,
+      title,
+      makerName ? [makerName] : [],
+      titleAnchor?.href || window.location.href,
+    );
+  },
+  insertLinksContainer: (item, linksContainer) => {
+    const workContentElement = item.querySelector<HTMLElement>(".work_content");
+    if (workContentElement) {
+      workContentElement.appendChild(linksContainer);
+    } else {
+      item.appendChild(linksContainer);
+    }
+  },
 };
 
-if (!document.getElementById("dlsite-cart-checker-root")) {
-  const rootElement = document.createElement("div");
-  rootElement.id = "dlsite-cart-checker-root";
-  document.body.appendChild(rootElement);
-  const root = createRoot(rootElement);
-  root.render(<DLsiteCartChecker />);
-} else {
-  console.log("[DLsite Cart Checker] Root element already exists.");
-}
+mountCartScrapboxChecker("dlsite-cart-checker-root", DLsiteCartCheckerConfig);

--- a/src/contentScript/DLsiteCart.tsx
+++ b/src/contentScript/DLsiteCart.tsx
@@ -3,55 +3,11 @@ import { createRoot } from "react-dom/client";
 import ScrapboxApiClient from "../scrapbox/scrapboxApi";
 import DLsiteProduct from "../DLsiteProduct"; // Changed import
 import { AcceptedService } from "../constant";
-import { createScrapboxPageUrl } from "../organism/CreatePageBar";
 import { StorageKeyProjectName } from "../chromeApi";
-import { ScrapboxPageDto } from "../scrapbox/searchDtos";
-
-type ScrapboxLinksDisplayProps = {
-  existPages: { name: string; url: string }[];
-  product: DLsiteProduct;
-  projectName: string;
-};
-
-const ScrapboxLinksDisplay: React.FC<ScrapboxLinksDisplayProps> = ({
-  existPages,
-  product,
-  projectName,
-}) => {
-  const pageCreationUrl = createScrapboxPageUrl(projectName, product);
-
-  return (
-    <div
-      style={{
-        marginTop: "8px",
-        fontSize: "12px",
-        padding: "5px",
-        border: "1px solid #ffcdd2",
-        backgroundColor: "#ffebee",
-      }}
-    >
-      <strong style={{ color: "#c62828" }}>もう買ってるかも:</strong>
-      {existPages.map((page) => (
-        <a
-          key={page.url}
-          href={page.url}
-          target="_blank"
-          style={{
-            marginLeft: "8px",
-            color: "#007bff",
-            textDecoration: "underline",
-          }}
-        >
-          {page.name}
-        </a>
-      ))}
-      {/* <br />
-      <a href={pageCreationUrl} target="_blank" style={{ marginTop: '4px', display: 'inline-block', color: '#28a745', textDecoration: 'underline' }}>
-        「{product.title}」のページを作成
-      </a> */}
-    </div>
-  );
-};
+import {
+  CartScrapboxLinksDisplay,
+  toCartScrapboxLinks,
+} from "./cartScrapboxLinks";
 
 const DLsiteCartChecker = () => {
   const [projectName, setProjectName] = React.useState<string | null>(null);
@@ -138,18 +94,9 @@ const DLsiteCartChecker = () => {
             }
 
             const root = createRoot(linksContainer);
-            const existPages = searchResult.pages.map((p: ScrapboxPageDto) => ({
-              name: p.title,
-              url: p.pageUrl,
-            }));
+            const existPages = toCartScrapboxLinks(searchResult.pages);
 
-            root.render(
-              <ScrapboxLinksDisplay
-                existPages={existPages}
-                product={product}
-                projectName={currentProjectName}
-              />,
-            );
+            root.render(<CartScrapboxLinksDisplay existPages={existPages} />);
           } else {
             console.log(
               `[DLsite Cart Checker] Not found in Scrapbox: ${title}`,

--- a/src/contentScript/DLsiteManiax.tsx
+++ b/src/contentScript/DLsiteManiax.tsx
@@ -23,10 +23,8 @@ class DLsiteManiax extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    const divElement = document.createElement("div");
-    divElement.id = this.ROOT_ELEM;
     const header = document.getElementById("header");
-    header.appendChild(divElement);
+    this.mountRootElement(header);
   }
 
   /**

--- a/src/contentScript/DLsiteManiax.tsx
+++ b/src/contentScript/DLsiteManiax.tsx
@@ -17,15 +17,7 @@ import {
  */
 class DLsiteManiax extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.dlsiteManiax;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    const header = document.getElementById("header");
-    this.mountRootElement(header);
-  }
+  protected readonly rootElementMountPoint = { target: "#header" };
 
   /**
    * 必要な情報をスクレイピングする

--- a/src/contentScript/DLsiteManiax.tsx
+++ b/src/contentScript/DLsiteManiax.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import Doujinshi from "../Doujinshi";
 import Asmr from "../Asmr";
 import Product from "../Product";
@@ -10,30 +9,21 @@ import {
   DLSITE_MANIAX_ASMR_TYPE,
   scrapeDLsiteManiaxData,
 } from "../scraping/dlsite-maniax-scraper";
+import { DLsiteManiaxScrapedData } from "../scraping/types";
 
 /**
  * DLSite maniaxやがるまに
  * を開いたときに実行される
  */
-class DLsiteManiax extends BaseContentScript {
+class DLsiteManiax extends DetailContentScript<DLsiteManiaxScrapedData> {
   protected readonly SERVICE = AcceptedService.dlsiteManiax;
   protected readonly rootElementMountPoint = { target: "#header" };
 
-  /**
-   * 必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Product {
-    const scrapedData = scrapeDLsiteManiaxData(document);
+  protected scrapeData(): DLsiteManiaxScrapedData | null {
+    return scrapeDLsiteManiaxData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
-    const publishedAt = scrapedData.publishedAt
-      ? dayjs(scrapedData.publishedAt)
-      : null;
-
+  protected createProduct(scrapedData: DLsiteManiaxScrapedData): Product {
     switch (scrapedData.type) {
       case DLSITE_MANIAX_ASMR_TYPE:
         return Asmr.make(
@@ -41,7 +31,7 @@ class DLsiteManiax extends BaseContentScript {
           scrapedData.title,
           scrapedData.authors,
           scrapedData.url,
-          publishedAt,
+          this.publishedAt(scrapedData.publishedAt),
           scrapedData.circleName,
           scrapedData.eventName,
           scrapedData.illustrators,
@@ -55,7 +45,7 @@ class DLsiteManiax extends BaseContentScript {
           scrapedData.title,
           scrapedData.authors,
           scrapedData.url,
-          publishedAt,
+          this.publishedAt(scrapedData.publishedAt),
           scrapedData.circleName,
           scrapedData.eventName,
         );

--- a/src/contentScript/DMMBasket.tsx
+++ b/src/contentScript/DMMBasket.tsx
@@ -3,58 +3,11 @@ import { createRoot } from "react-dom/client";
 import ScrapboxApiClient from "../scrapbox/scrapboxApi";
 import Doujinshi from "../Doujinshi";
 import { AcceptedService } from "../constant";
-import Product from "../Product"; // Needed for createScrapboxPageUrl type
-import { createScrapboxPageUrl } from "../organism/CreatePageBar"; // For the "create page" link
 import { StorageKeyProjectName } from "../chromeApi";
-import { ScrapboxPageDto } from "../scrapbox/searchDtos";
-
-// Define the new component for displaying Scrapbox links
-type ScrapboxLinksDisplayProps = {
-  existPages: { name: string; url: string }[];
-  product: Product; // Using base Product type
-  projectName: string;
-};
-
-const ScrapboxLinksDisplay: React.FC<ScrapboxLinksDisplayProps> = ({
-  existPages,
-  product,
-  projectName,
-}) => {
-  const pageCreationUrl = createScrapboxPageUrl(projectName, product);
-
-  return (
-    <div
-      style={{
-        marginTop: "8px",
-        fontSize: "12px",
-        padding: "5px",
-        border: "1px solid #ffcdd2",
-        backgroundColor: "#ffebee",
-      }}
-    >
-      <strong style={{ color: "#c62828" }}>もう買ってるかも:</strong>
-      {existPages.map((page) => (
-        <a
-          key={page.url}
-          href={page.url}
-          target="_blank"
-          style={{
-            marginLeft: "8px",
-            color: "#007bff",
-            textDecoration: "underline",
-          }}
-        >
-          {page.name}
-        </a>
-      ))}
-      {/* Remove create page link per user request */}
-      {/* <br />
-      <a href={pageCreationUrl} target="_blank" style={{ marginTop: '4px', display: 'inline-block', color: '#28a745', textDecoration: 'underline' }}>
-        「{product.title}」のページを作成
-      </a> */}
-    </div>
-  );
-};
+import {
+  CartScrapboxLinksDisplay,
+  toCartScrapboxLinks,
+} from "./cartScrapboxLinks";
 
 const DMMBasketChecker = () => {
   const [projectName, setProjectName] = React.useState<string | null>(null);
@@ -161,18 +114,9 @@ const DMMBasketChecker = () => {
             }
 
             const root = createRoot(linksContainer);
-            const existPages = searchResult.pages.map((p: ScrapboxPageDto) => ({
-              name: p.title,
-              url: p.pageUrl,
-            }));
+            const existPages = toCartScrapboxLinks(searchResult.pages);
 
-            root.render(
-              <ScrapboxLinksDisplay
-                existPages={existPages}
-                product={product}
-                projectName={currentProjectName}
-              />,
-            );
+            root.render(<CartScrapboxLinksDisplay existPages={existPages} />);
           } else {
             console.log(`[DMM Basket Checker] Not found in Scrapbox: ${title}`);
           }

--- a/src/contentScript/DMMBasket.tsx
+++ b/src/contentScript/DMMBasket.tsx
@@ -1,222 +1,60 @@
-import * as React from "react";
-import { createRoot } from "react-dom/client";
-import ScrapboxApiClient from "../scrapbox/scrapboxApi";
 import Doujinshi from "../Doujinshi";
 import { AcceptedService } from "../constant";
-import { StorageKeyProjectName } from "../chromeApi";
 import {
-  CartScrapboxLinksDisplay,
-  toCartScrapboxLinks,
-} from "./cartScrapboxLinks";
+  CartScrapboxCheckerConfig,
+  mountCartScrapboxChecker,
+} from "./CartScrapboxChecker";
 
-const DMMBasketChecker = () => {
-  const [projectName, setProjectName] = React.useState<string | null>(null);
+const DMMBasketCheckerConfig: CartScrapboxCheckerConfig = {
+  logPrefix: "[DMM Basket Checker]",
+  missingProjectNameMessage:
+    "[DMM Basket Checker] Scrapbox project name is not set in Chrome storage. Please set it in the extension options.",
+  observerTargetSelector: "ul.basket-list",
+  observerTargetDescription: "ul.basket-list",
+  itemSelector: "li.basket-listItem",
+  createProduct: (item) => {
+    const titleAnchor =
+      item.querySelector<HTMLAnchorElement>("b.basket-name a");
+    const title = titleAnchor?.innerText.trim();
+    if (!title) {
+      return null;
+    }
 
-  React.useEffect(() => {
-    chrome.storage.sync.get([StorageKeyProjectName], (result) => {
-      const storedProjectName = result[StorageKeyProjectName];
-      if (typeof storedProjectName === "string" && storedProjectName.trim()) {
-        setProjectName(storedProjectName);
-      } else {
-        console.warn(
-          "[DMM Basket Checker] Scrapbox project name is not set in Chrome storage. Please set it in the extension options.",
-        );
-      }
-    });
-  }, []);
+    return Doujinshi.make(
+      AcceptedService.dmmDoujinBasket,
+      title,
+      [],
+      titleAnchor?.href || window.location.href,
+      null,
+      item.querySelector<HTMLElement>("p.basket-circle a")?.innerText?.trim() ||
+        null,
+      null,
+    );
+  },
+  insertLinksContainer: (item, linksContainer) => {
+    const circleElement = item.querySelector<HTMLElement>("p.basket-circle");
+    const titleElement = item.querySelector<HTMLElement>("b.basket-name");
+    const parentOfCircleOrTitle =
+      item.querySelector<HTMLElement>(".basket-txtContent");
 
-  const processCartItem = React.useCallback(
-    async (
-      item: HTMLElement,
-      currentProjectName: string,
-      processedItems: WeakSet<HTMLElement>,
-    ) => {
-      if (processedItems.has(item) || !currentProjectName) {
-        return;
-      }
-      processedItems.add(item);
-
-      const titleAnchor =
-        item.querySelector<HTMLAnchorElement>("b.basket-name a");
-      const title = titleAnchor?.innerText.trim();
-      const itemUrl = titleAnchor?.href;
-
-      if (title) {
-        console.log(`[DMM Basket Checker] Checking: ${title}`);
-        const apiClient = new ScrapboxApiClient();
-        try {
-          const product = Doujinshi.make(
-            AcceptedService.dmmDoujinBasket, // service
-            title, // title
-            [], // authors
-            itemUrl || window.location.href, // url
-            null, // publishedAt
-            (
-              item.querySelector("p.basket-circle a") as HTMLElement
-            )?.innerText?.trim() || null, // circleName (from brandName)
-            null, // eventName (from seriesName)
-          );
-
-          const searchResult = await apiClient.search({ product });
-          console.log(
-            `[DMM Basket Checker] searchResult for "${title}":`,
-            searchResult,
-          ); // Log searchResult
-
-          if (
-            searchResult &&
-            searchResult.count > 0 &&
-            searchResult.pages &&
-            searchResult.pages.length > 0
-          ) {
-            // Added checks for searchResult and searchResult.pages
-            console.log(
-              `[DMM Basket Checker] Found in Scrapbox: ${title}. Count: ${searchResult.count}, Pages:`,
-              searchResult.pages,
-            );
-            const linksContainerId = `scrapbox-links-${encodeURIComponent(title.substring(0, 10))}-${Math.random().toString(36).substring(2, 7)}`;
-            let linksContainer = item.querySelector<HTMLElement>(
-              `.scrapbox-links-container`,
-            );
-
-            if (linksContainer) {
-              linksContainer.remove();
-            }
-
-            linksContainer = document.createElement("div");
-            linksContainer.id = linksContainerId;
-            linksContainer.className = "scrapbox-links-container"; // New class name
-
-            // Try to insert after the circle name, then after title, then fallback
-            const circleElement =
-              item.querySelector<HTMLElement>("p.basket-circle");
-            const titleElement =
-              item.querySelector<HTMLElement>("b.basket-name");
-            const parentOfCircleOrTitle =
-              item.querySelector<HTMLElement>(".basket-txtContent");
-
-            if (circleElement && circleElement.parentNode) {
-              circleElement.parentNode.insertBefore(
-                linksContainer,
-                circleElement.nextSibling,
-              );
-            } else if (titleElement && titleElement.parentNode) {
-              titleElement.parentNode.insertBefore(
-                linksContainer,
-                titleElement.nextSibling,
-              );
-            } else if (parentOfCircleOrTitle) {
-              parentOfCircleOrTitle.appendChild(linksContainer); // Fallback to end of basket-txtContent
-            } else {
-              item
-                .querySelector<HTMLElement>(".basket-descCol")
-                ?.appendChild(linksContainer); // Absolute fallback
-            }
-
-            const root = createRoot(linksContainer);
-            const existPages = toCartScrapboxLinks(searchResult.pages);
-
-            root.render(<CartScrapboxLinksDisplay existPages={existPages} />);
-          } else {
-            console.log(`[DMM Basket Checker] Not found in Scrapbox: ${title}`);
-          }
-        } catch (error) {
-          console.error(
-            "[DMM Basket Checker] Error searching Scrapbox:",
-            error,
-          );
-        }
-      }
-    },
-    [],
-  );
-
-  React.useEffect(() => {
-    if (!projectName) return;
-
-    const processedItems = new WeakSet<HTMLElement>();
-
-    const handleMutations = (mutationsList: MutationRecord[]) => {
-      for (const mutation of mutationsList) {
-        if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
-          mutation.addedNodes.forEach((node) => {
-            if (node.nodeType === Node.ELEMENT_NODE) {
-              const elementNode = node as HTMLElement;
-              // 追加されたノード自体がカートアイテムの場合
-              if (
-                elementNode.matches &&
-                elementNode.matches("li.basket-listItem")
-              ) {
-                processCartItem(elementNode, projectName, processedItems);
-              }
-              // 追加されたノードの子孫にカートアイテムが含まれる場合
-              elementNode
-                .querySelectorAll<HTMLElement>("li.basket-listItem")
-                .forEach((item) => {
-                  processCartItem(item, projectName, processedItems);
-                });
-            }
-          });
-        }
-      }
-    };
-
-    let observer: MutationObserver | null = null;
-
-    const setupObserver = (targetNode: HTMLElement) => {
-      observer = new MutationObserver(handleMutations);
-      observer.observe(targetNode, { childList: true, subtree: true });
-      // 初期表示時のアイテムも処理
-      const initialItems =
-        document.querySelectorAll<HTMLElement>("li.basket-listItem");
-      initialItems.forEach((item) =>
-        processCartItem(item, projectName, processedItems),
+    if (circleElement?.parentNode) {
+      circleElement.parentNode.insertBefore(
+        linksContainer,
+        circleElement.nextSibling,
       );
-    };
-
-    const pollForBasketList = (retries = 10, interval = 500) => {
-      const targetNode = document.querySelector<HTMLElement>("ul.basket-list");
-      if (targetNode) {
-        console.log(
-          "[DMM Basket Checker] Target node 'ul.basket-list' found. Setting up MutationObserver.",
-        );
-        setupObserver(targetNode);
-      } else if (retries > 0) {
-        console.log(
-          `[DMM Basket Checker] 'ul.basket-list' not found. Retrying in ${interval}ms... (${retries} retries left)`,
-        );
-        setTimeout(() => pollForBasketList(retries - 1, interval), interval);
-      } else {
-        console.error(
-          "[DMM Basket Checker] Target node 'ul.basket-list' not found after multiple retries. Observer not set up.",
-        );
-      }
-    };
-
-    pollForBasketList();
-
-    return () => {
-      if (observer) {
-        observer.disconnect();
-      }
-      // Clean up any injected alert bars if the component unmounts or projectName changes
-      document
-        .querySelectorAll(".scrapbox-alert-container")
-        .forEach((el) => el.remove());
-    };
-  }, [projectName, processCartItem]);
-
-  return null;
+    } else if (titleElement?.parentNode) {
+      titleElement.parentNode.insertBefore(
+        linksContainer,
+        titleElement.nextSibling,
+      );
+    } else if (parentOfCircleOrTitle) {
+      parentOfCircleOrTitle.appendChild(linksContainer);
+    } else {
+      item
+        .querySelector<HTMLElement>(".basket-descCol")
+        ?.appendChild(linksContainer);
+    }
+  },
 };
 
-// Content scriptのエントリーポイント
-// 既に同名のIDを持つ要素がないか確認
-if (!document.getElementById("dmm-basket-checker-root")) {
-  const rootElement = document.createElement("div");
-  rootElement.id = "dmm-basket-checker-root";
-  document.body.appendChild(rootElement);
-  const root = createRoot(rootElement);
-  root.render(<DMMBasketChecker />);
-} else {
-  console.log("[DMM Basket Checker] Root element already exists.");
-}
+mountCartScrapboxChecker("dmm-basket-checker-root", DMMBasketCheckerConfig);

--- a/src/contentScript/DetailContentScript.ts
+++ b/src/contentScript/DetailContentScript.ts
@@ -1,0 +1,24 @@
+import dayjs from "dayjs";
+import Product from "../Product";
+import { BaseContentScript } from "./BaseContentScript";
+
+export abstract class DetailContentScript<
+  TScrapedData,
+> extends BaseContentScript {
+  protected abstract scrapeData(): TScrapedData | null;
+
+  protected abstract createProduct(scrapedData: TScrapedData): Product;
+
+  protected scrape(): Product | null {
+    const scrapedData = this.scrapeData();
+    if (!scrapedData) {
+      return null;
+    }
+
+    return this.createProduct(scrapedData);
+  }
+
+  protected publishedAt(date: Date | null): dayjs.Dayjs | null {
+    return date ? dayjs(date) : null;
+  }
+}

--- a/src/contentScript/FanzaAnime.tsx
+++ b/src/contentScript/FanzaAnime.tsx
@@ -13,13 +13,11 @@ class FanzaAnime extends BaseContentScript {
   protected readonly waitForDynamicContent = true;
 
   protected createElementForBar(): void {
-    const rootElement = this.createRootElement();
-
     // ヘッダー直後に要素を配置する
     const header = document.querySelector("header");
 
     // より安全なinsertAdjacentElementを使用
-    header.insertAdjacentElement("afterend", rootElement);
+    this.mountRootElement(header, "afterend");
   }
 
   protected scrape(): Film | null {

--- a/src/contentScript/FanzaAnime.tsx
+++ b/src/contentScript/FanzaAnime.tsx
@@ -11,14 +11,10 @@ class FanzaAnime extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.fanzaAnime;
   // SPAで本文が後から描画されるため、DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
-
-  protected createElementForBar(): void {
-    // ヘッダー直後に要素を配置する
-    const header = document.querySelector("header");
-
-    // より安全なinsertAdjacentElementを使用
-    this.mountRootElement(header, "afterend");
-  }
+  protected readonly rootElementMountPoint = {
+    target: "header",
+    position: "afterend" as const,
+  };
 
   protected scrape(): Film | null {
     const scrapedData = scrapeFanzaAnimeData(document);

--- a/src/contentScript/FanzaAnime.tsx
+++ b/src/contentScript/FanzaAnime.tsx
@@ -1,13 +1,13 @@
 // CSSを有効にする
 import "../organism/Bar.scss";
 
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
 import Film from "../Film";
 import { scrapeFanzaAnimeData } from "../scraping/fanza-anime-scraper";
+import { FanzaAnimeScrapedData } from "../scraping/types";
 
-class FanzaAnime extends BaseContentScript {
+class FanzaAnime extends DetailContentScript<FanzaAnimeScrapedData> {
   protected readonly SERVICE = AcceptedService.fanzaAnime;
   // SPAで本文が後から描画されるため、DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
@@ -16,19 +16,18 @@ class FanzaAnime extends BaseContentScript {
     position: "afterend" as const,
   };
 
-  protected scrape(): Film | null {
-    const scrapedData = scrapeFanzaAnimeData(document);
-    if (!scrapedData) {
-      return null;
-    }
+  protected scrapeData(): FanzaAnimeScrapedData | null {
+    return scrapeFanzaAnimeData(document);
+  }
 
+  protected createProduct(scrapedData: FanzaAnimeScrapedData): Film {
     return Film.make(
       AcceptedService.fanzaAnime,
       scrapedData.title,
       scrapedData.actress,
       scrapedData.director,
       scrapedData.url,
-      scrapedData.publishedAt ? dayjs(scrapedData.publishedAt) : null,
+      this.publishedAt(scrapedData.publishedAt),
       scrapedData.label,
       scrapedData.manufacturerProductNumber,
     );

--- a/src/contentScript/FanzaBooks.tsx
+++ b/src/contentScript/FanzaBooks.tsx
@@ -1,15 +1,15 @@
 import Book from "../Book";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import { scrapeFanzaBooksData } from "../scraping/fanza-books-scraper";
+import { FanzaBooksScrapedData } from "../scraping/types";
 
 /**
  * FANZAのページを開いたときに実行される
  * https://book.dmm.co.jp/detail/*
  */
-class FanzaBooks extends BaseContentScript {
+class FanzaBooks extends DetailContentScript<FanzaBooksScrapedData> {
   protected readonly SERVICE = AcceptedService.fanza;
   // 2023年4月ごろのアップデートでBFFで後から動的に情報を取得するようになったため、
   // DOMの変化を待って再scrapeする。
@@ -19,17 +19,11 @@ class FanzaBooks extends BaseContentScript {
     position: "afterend" as const,
   };
 
-  /**
-   * Fanzaのページから必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Book {
-    const scrapedData = scrapeFanzaBooksData(document);
+  protected scrapeData(): FanzaBooksScrapedData | null {
+    return scrapeFanzaBooksData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
+  protected createProduct(scrapedData: FanzaBooksScrapedData): Book {
     // background scriptに送る
     return Book.make(
       AcceptedService.fanza,
@@ -38,7 +32,7 @@ class FanzaBooks extends BaseContentScript {
       scrapedData.url,
       scrapedData.publisher,
       scrapedData.label,
-      scrapedData.publishedAt ? dayjs(scrapedData.publishedAt) : null,
+      this.publishedAt(scrapedData.publishedAt),
     );
   }
 }

--- a/src/contentScript/FanzaBooks.tsx
+++ b/src/contentScript/FanzaBooks.tsx
@@ -20,10 +20,8 @@ class FanzaBooks extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    const textarea = document.createElement("div");
-    textarea.id = this.ROOT_ELEM;
     const header = document.querySelector("header");
-    header.parentNode.insertBefore(textarea, header.nextSibling);
+    this.mountRootElement(header, "afterend");
   }
 
   /**

--- a/src/contentScript/FanzaBooks.tsx
+++ b/src/contentScript/FanzaBooks.tsx
@@ -14,15 +14,10 @@ class FanzaBooks extends BaseContentScript {
   // 2023年4月ごろのアップデートでBFFで後から動的に情報を取得するようになったため、
   // DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    const header = document.querySelector("header");
-    this.mountRootElement(header, "afterend");
-  }
+  protected readonly rootElementMountPoint = {
+    target: "header",
+    position: "afterend" as const,
+  };
 
   /**
    * Fanzaのページから必要な情報をスクレイピングする

--- a/src/contentScript/FanzaDoujin.tsx
+++ b/src/contentScript/FanzaDoujin.tsx
@@ -11,23 +11,14 @@ import { scrapeFanzaDoujinData } from "../scraping/fanza-doujin-scraper";
  */
 class FanzaDoujin extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.fanzaDojin;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    // サイトの適当な要素につける
-    const header = document.getElementsByTagName("header")[0];
-    if (header) {
+  protected readonly rootElementMountPoint = {
+    target: () => document.getElementsByTagName("header")[0] ?? null,
+    prepareTarget: (target: Element) => {
       // appendした子要素も高さに含んでほしい
-      header.style.height = "auto";
-      this.mountRootElement(header);
-    } else {
-      // headerがない場合はbodyの最初に追加
-      this.mountRootElementAtBodyStart();
-    }
-  }
+      (target as HTMLElement).style.height = "auto";
+    },
+    fallback: "bodyStart" as const,
+  };
 
   /**
    * Fanzaのページから必要な情報をスクレイピングする

--- a/src/contentScript/FanzaDoujin.tsx
+++ b/src/contentScript/FanzaDoujin.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import Doujinshi from "../Doujinshi";
 import { scrapeFanzaDoujinData } from "../scraping/fanza-doujin-scraper";
+import { FanzaDoujinScrapedData } from "../scraping/types";
 
 /**
  * FANZAのページを開いたときに実行される
  */
-class FanzaDoujin extends BaseContentScript {
+class FanzaDoujin extends DetailContentScript<FanzaDoujinScrapedData> {
   protected readonly SERVICE = AcceptedService.fanzaDojin;
   protected readonly rootElementMountPoint = {
     target: () => document.getElementsByTagName("header")[0] ?? null,
@@ -20,24 +20,18 @@ class FanzaDoujin extends BaseContentScript {
     fallback: "bodyStart" as const,
   };
 
-  /**
-   * Fanzaのページから必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Doujinshi {
-    const scrapedData = scrapeFanzaDoujinData(document);
+  protected scrapeData(): FanzaDoujinScrapedData | null {
+    return scrapeFanzaDoujinData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
+  protected createProduct(scrapedData: FanzaDoujinScrapedData): Doujinshi {
     // background scriptに送る
     return Doujinshi.make(
       AcceptedService.fanzaDojin,
       scrapedData.title,
       scrapedData.authors,
       scrapedData.url,
-      scrapedData.publishedAt ? dayjs(scrapedData.publishedAt) : null,
+      this.publishedAt(scrapedData.publishedAt),
       scrapedData.circleName,
       null,
     );

--- a/src/contentScript/FanzaDoujin.tsx
+++ b/src/contentScript/FanzaDoujin.tsx
@@ -17,22 +17,15 @@ class FanzaDoujin extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    const rootElement = this.createRootElement();
-
     // サイトの適当な要素につける
     const header = document.getElementsByTagName("header")[0];
     if (header) {
       // appendした子要素も高さに含んでほしい
       header.style.height = "auto";
-      header.appendChild(rootElement);
+      this.mountRootElement(header);
     } else {
       // headerがない場合はbodyの最初に追加
-      const body = document.body;
-      if (body && body.firstChild) {
-        body.insertBefore(rootElement, body.firstChild);
-      } else if (body) {
-        body.appendChild(rootElement);
-      }
+      this.mountRootElementAtBodyStart();
     }
   }
 

--- a/src/contentScript/FanzaVideo.tsx
+++ b/src/contentScript/FanzaVideo.tsx
@@ -13,22 +13,15 @@ class FanzaVideo extends BaseContentScript {
   protected readonly waitForDynamicContent = true;
 
   protected createElementForBar(): void {
-    const rootElement = this.createRootElement();
-
     // ヘッダー直後に要素を配置する（www.dmm.co.jpの場合）
     const header = document.querySelector("header");
 
     if (header) {
       // より安全なinsertAdjacentElementを使用
-      header.insertAdjacentElement("afterend", rootElement);
+      this.mountRootElement(header, "afterend");
     } else {
       // headerが存在しない場合（video.dmm.co.jpなど）はbody直後に配置
-      const body = document.querySelector("body");
-      if (body && body.firstChild) {
-        body.insertBefore(rootElement, body.firstChild);
-      } else if (body) {
-        body.appendChild(rootElement);
-      }
+      this.mountRootElementAtBodyStart();
     }
   }
 

--- a/src/contentScript/FanzaVideo.tsx
+++ b/src/contentScript/FanzaVideo.tsx
@@ -11,19 +11,11 @@ class FanzaVideo extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.fanzaVideo;
   // 本文が後から動的に描画されるため、DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
-
-  protected createElementForBar(): void {
-    // ヘッダー直後に要素を配置する（www.dmm.co.jpの場合）
-    const header = document.querySelector("header");
-
-    if (header) {
-      // より安全なinsertAdjacentElementを使用
-      this.mountRootElement(header, "afterend");
-    } else {
-      // headerが存在しない場合（video.dmm.co.jpなど）はbody直後に配置
-      this.mountRootElementAtBodyStart();
-    }
-  }
+  protected readonly rootElementMountPoint = {
+    target: "header",
+    position: "afterend" as const,
+    fallback: "bodyStart" as const,
+  };
 
   protected scrape(): Film {
     const scrapedData = scrapeFanzaVideoData(document);

--- a/src/contentScript/FanzaVideo.tsx
+++ b/src/contentScript/FanzaVideo.tsx
@@ -1,13 +1,13 @@
 // CSSを有効にする
 import "../organism/Bar.scss";
 
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
 import Film from "../Film";
 import { scrapeFanzaVideoData } from "../scraping/fanza-video-scraper";
+import { FanzaVideoScrapedData } from "../scraping/types";
 
-class FanzaVideo extends BaseContentScript {
+class FanzaVideo extends DetailContentScript<FanzaVideoScrapedData> {
   protected readonly SERVICE = AcceptedService.fanzaVideo;
   // 本文が後から動的に描画されるため、DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
@@ -17,12 +17,11 @@ class FanzaVideo extends BaseContentScript {
     fallback: "bodyStart" as const,
   };
 
-  protected scrape(): Film {
-    const scrapedData = scrapeFanzaVideoData(document);
+  protected scrapeData(): FanzaVideoScrapedData | null {
+    return scrapeFanzaVideoData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
+  protected createProduct(scrapedData: FanzaVideoScrapedData): Film {
     // background scriptに送る
     return Film.make(
       AcceptedService.fanzaVideo,
@@ -30,7 +29,7 @@ class FanzaVideo extends BaseContentScript {
       scrapedData.actress,
       scrapedData.director,
       scrapedData.url,
-      scrapedData.publishedAt ? dayjs(scrapedData.publishedAt) : null,
+      this.publishedAt(scrapedData.publishedAt),
       scrapedData.label,
       scrapedData.id,
     );

--- a/src/contentScript/Fc2ContentMarket.tsx
+++ b/src/contentScript/Fc2ContentMarket.tsx
@@ -9,14 +9,10 @@ import { scrapeFc2ContentMarketData } from "../scraping/fc2-content-market-scrap
 
 class FC2ContentMarket extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.fc2ContentMarket;
-
-  protected createElementForBar(): void {
-    // ヘッダー直後に要素を配置する
-    const header = document.querySelector("header");
-
-    // より安全なinsertAdjacentElementを使用
-    this.mountRootElement(header, "afterend");
-  }
+  protected readonly rootElementMountPoint = {
+    target: "header",
+    position: "afterend" as const,
+  };
 
   protected scrape(): Film {
     const scrapedData = scrapeFc2ContentMarketData(document);

--- a/src/contentScript/Fc2ContentMarket.tsx
+++ b/src/contentScript/Fc2ContentMarket.tsx
@@ -1,26 +1,24 @@
 // CSSを有効にする
 import "../organism/Bar.scss";
 
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
 import Film from "../Film";
 import { scrapeFc2ContentMarketData } from "../scraping/fc2-content-market-scraper";
+import { Fc2ContentMarketScrapedData } from "../scraping/types";
 
-class FC2ContentMarket extends BaseContentScript {
+class FC2ContentMarket extends DetailContentScript<Fc2ContentMarketScrapedData> {
   protected readonly SERVICE = AcceptedService.fc2ContentMarket;
   protected readonly rootElementMountPoint = {
     target: "header",
     position: "afterend" as const,
   };
 
-  protected scrape(): Film {
-    const scrapedData = scrapeFc2ContentMarketData(document);
+  protected scrapeData(): Fc2ContentMarketScrapedData | null {
+    return scrapeFc2ContentMarketData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
+  protected createProduct(scrapedData: Fc2ContentMarketScrapedData): Film {
     // background scriptに送る
     return Film.make(
       this.SERVICE,
@@ -28,7 +26,7 @@ class FC2ContentMarket extends BaseContentScript {
       [], // actress
       scrapedData.director === "" ? null : scrapedData.director,
       scrapedData.url,
-      scrapedData.publishedAt ? dayjs(scrapedData.publishedAt) : null,
+      this.publishedAt(scrapedData.publishedAt),
       "", // label
       scrapedData.id,
     );

--- a/src/contentScript/Fc2ContentMarket.tsx
+++ b/src/contentScript/Fc2ContentMarket.tsx
@@ -11,13 +11,11 @@ class FC2ContentMarket extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.fc2ContentMarket;
 
   protected createElementForBar(): void {
-    const rootElement = this.createRootElement();
-
     // ヘッダー直後に要素を配置する
     const header = document.querySelector("header");
 
     // より安全なinsertAdjacentElementを使用
-    header.insertAdjacentElement("afterend", rootElement);
+    this.mountRootElement(header, "afterend");
   }
 
   protected scrape(): Film {

--- a/src/contentScript/Melonbooks.tsx
+++ b/src/contentScript/Melonbooks.tsx
@@ -17,12 +17,9 @@ class Melonbooks extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    // 表示用のエレメント作成
-    const divElementForBar = document.createElement("div");
-    divElementForBar.id = this.ROOT_ELEM;
     // サイトの適当な要素につける
     const header = document.querySelector("#header_free_html");
-    header.appendChild(divElementForBar);
+    this.mountRootElement(header);
   }
 
   /**

--- a/src/contentScript/Melonbooks.tsx
+++ b/src/contentScript/Melonbooks.tsx
@@ -11,16 +11,7 @@ import { scrapeMelonbooksData } from "../scraping/melonbooks-scraper";
  */
 class Melonbooks extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.melonbooks;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    // サイトの適当な要素につける
-    const header = document.querySelector("#header_free_html");
-    this.mountRootElement(header);
-  }
+  protected readonly rootElementMountPoint = { target: "#header_free_html" };
 
   /**
    * 必要な情報をスクレイピングする

--- a/src/contentScript/Melonbooks.tsx
+++ b/src/contentScript/Melonbooks.tsx
@@ -1,40 +1,30 @@
 import * as React from "react";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import Doujinshi from "../Doujinshi";
 import { scrapeMelonbooksData } from "../scraping/melonbooks-scraper";
+import { MelonbooksScrapedData } from "../scraping/types";
 
 /**
  * メロンブックスのページを開いたときに実行される
  */
-class Melonbooks extends BaseContentScript {
+class Melonbooks extends DetailContentScript<MelonbooksScrapedData> {
   protected readonly SERVICE = AcceptedService.melonbooks;
   protected readonly rootElementMountPoint = { target: "#header_free_html" };
 
-  /**
-   * 必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Doujinshi {
-    const scrapedData = scrapeMelonbooksData(document);
+  protected scrapeData(): MelonbooksScrapedData | null {
+    return scrapeMelonbooksData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
-    const publishedAt = scrapedData.publishedAt
-      ? dayjs(scrapedData.publishedAt)
-      : null;
-
+  protected createProduct(scrapedData: MelonbooksScrapedData): Doujinshi {
     // background scriptに送る
     return Doujinshi.make(
       AcceptedService.melonbooks,
       scrapedData.title,
       scrapedData.authors,
       scrapedData.url,
-      publishedAt,
+      this.publishedAt(scrapedData.publishedAt),
       scrapedData.circleName,
       scrapedData.eventName,
     );

--- a/src/contentScript/Surugaya.tsx
+++ b/src/contentScript/Surugaya.tsx
@@ -15,17 +15,9 @@ import { scrapeSurugayaData } from "../scraping/surugaya-scraper";
  */
 class Surugaya extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.surugaya;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    const header = document.querySelector(
-      "body > div.dialog-off-canvas-main-canvas > header > div.top_nav",
-    );
-    this.mountRootElement(header);
-  }
+  protected readonly rootElementMountPoint = {
+    target: "body > div.dialog-off-canvas-main-canvas > header > div.top_nav",
+  };
 
   /**
    * ページから必要な情報をスクレイピングする

--- a/src/contentScript/Surugaya.tsx
+++ b/src/contentScript/Surugaya.tsx
@@ -21,12 +21,10 @@ class Surugaya extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    const textarea = document.createElement("div");
-    textarea.id = this.ROOT_ELEM;
     const header = document.querySelector(
       "body > div.dialog-off-canvas-main-canvas > header > div.top_nav",
     );
-    header.appendChild(textarea);
+    this.mountRootElement(header);
   }
 
   /**

--- a/src/contentScript/Surugaya.tsx
+++ b/src/contentScript/Surugaya.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import Doujinshi from "../Doujinshi";
 import { scrapeSurugayaData } from "../scraping/surugaya-scraper";
+import { SurugayaScrapedData } from "../scraping/types";
 
 /**
  * 駿河屋のページを開いたときに実行される
@@ -13,34 +13,24 @@ import { scrapeSurugayaData } from "../scraping/surugaya-scraper";
  * ページスクショ：
  * https://gyazo.com/369f88d61f358ea642d91964e5c682fc
  */
-class Surugaya extends BaseContentScript {
+class Surugaya extends DetailContentScript<SurugayaScrapedData> {
   protected readonly SERVICE = AcceptedService.surugaya;
   protected readonly rootElementMountPoint = {
     target: "body > div.dialog-off-canvas-main-canvas > header > div.top_nav",
   };
 
-  /**
-   * ページから必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Doujinshi {
-    const scrapedData = scrapeSurugayaData(document);
+  protected scrapeData(): SurugayaScrapedData | null {
+    return scrapeSurugayaData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
-    const publishedAt = scrapedData.publishedAt
-      ? dayjs(scrapedData.publishedAt)
-      : null;
-
+  protected createProduct(scrapedData: SurugayaScrapedData): Doujinshi {
     // background scriptに送る
     return Doujinshi.make(
       AcceptedService.surugaya,
       scrapedData.title,
       scrapedData.authors,
       scrapedData.url,
-      publishedAt,
+      this.publishedAt(scrapedData.publishedAt),
       scrapedData.publisher,
       null,
     );

--- a/src/contentScript/Toranoana.tsx
+++ b/src/contentScript/Toranoana.tsx
@@ -18,12 +18,9 @@ class Toranoana extends BaseContentScript {
    * @private
    */
   protected createElementForBar() {
-    // 表示用のエレメント作成
-    const divElementForBar = document.createElement("div");
-    divElementForBar.id = this.ROOT_ELEM;
     // サイトの適当な要素につける
     const header = document.querySelector("header");
-    header.appendChild(divElementForBar);
+    this.mountRootElement(header);
   }
 
   /**

--- a/src/contentScript/Toranoana.tsx
+++ b/src/contentScript/Toranoana.tsx
@@ -1,41 +1,31 @@
 import * as React from "react";
 import "../organism/Bar.scss";
 import { AcceptedService } from "../constant";
-import dayjs from "dayjs";
-import { BaseContentScript } from "./BaseContentScript";
+import { DetailContentScript } from "./DetailContentScript";
 import Doujinshi from "../Doujinshi";
 import { scrapeToranoanaData } from "../scraping/toranoana-scraper";
+import { ToranoanaScrapedData } from "../scraping/types";
 
 /**
  * とらのあなのページを開いたときに実行される
  * https://ec.toranoana.jp/tora_r/ec/item/
  */
-class Toranoana extends BaseContentScript {
+class Toranoana extends DetailContentScript<ToranoanaScrapedData> {
   protected readonly SERVICE = AcceptedService.toranoana;
   protected readonly rootElementMountPoint = { target: "header" };
 
-  /**
-   * 必要な情報をスクレイピングする
-   * @private
-   */
-  protected scrape(): Doujinshi {
-    const scrapedData = scrapeToranoanaData(document);
+  protected scrapeData(): ToranoanaScrapedData | null {
+    return scrapeToranoanaData(document);
+  }
 
-    if (!scrapedData) {
-      return null;
-    }
-
-    const publishedAt = scrapedData.publishedAt
-      ? dayjs(scrapedData.publishedAt)
-      : null;
-
+  protected createProduct(scrapedData: ToranoanaScrapedData): Doujinshi {
     // background scriptに送る
     return Doujinshi.make(
       AcceptedService.toranoana,
       scrapedData.title,
       scrapedData.authors,
       scrapedData.url,
-      publishedAt,
+      this.publishedAt(scrapedData.publishedAt),
       scrapedData.circleName,
       scrapedData.eventName || "",
     );

--- a/src/contentScript/Toranoana.tsx
+++ b/src/contentScript/Toranoana.tsx
@@ -12,16 +12,7 @@ import { scrapeToranoanaData } from "../scraping/toranoana-scraper";
  */
 class Toranoana extends BaseContentScript {
   protected readonly SERVICE = AcceptedService.toranoana;
-
-  /**
-   * バー表示用のdiv要素を生成
-   * @private
-   */
-  protected createElementForBar() {
-    // サイトの適当な要素につける
-    const header = document.querySelector("header");
-    this.mountRootElement(header);
-  }
+  protected readonly rootElementMountPoint = { target: "header" };
 
   /**
    * 必要な情報をスクレイピングする

--- a/src/contentScript/cartScrapboxLinks.tsx
+++ b/src/contentScript/cartScrapboxLinks.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { ScrapboxPageDto } from "../scrapbox/searchDtos";
+
+export type CartScrapboxLink = {
+  name: string;
+  url: string;
+};
+
+type CartScrapboxLinksDisplayProps = {
+  existPages: CartScrapboxLink[];
+};
+
+export const CartScrapboxLinksDisplay: React.FC<
+  CartScrapboxLinksDisplayProps
+> = ({ existPages }) => {
+  return (
+    <div
+      style={{
+        marginTop: "8px",
+        fontSize: "12px",
+        padding: "5px",
+        border: "1px solid #ffcdd2",
+        backgroundColor: "#ffebee",
+      }}
+    >
+      <strong style={{ color: "#c62828" }}>もう買ってるかも:</strong>
+      {existPages.map((page) => (
+        <a
+          key={page.url}
+          href={page.url}
+          target="_blank"
+          style={{
+            marginLeft: "8px",
+            color: "#007bff",
+            textDecoration: "underline",
+          }}
+        >
+          {page.name}
+        </a>
+      ))}
+    </div>
+  );
+};
+
+export function toCartScrapboxLinks(
+  pages: ScrapboxPageDto[],
+): CartScrapboxLink[] {
+  return pages.map((p) => ({
+    name: p.title,
+    url: p.pageUrl,
+  }));
+}


### PR DESCRIPTION
## Summary
- Centralize content script bar mounting and declarative mount point configuration.
- Split detail-page scraping from Product creation via `DetailContentScript`.
- Share DMMBasket / DLsiteCart Scrapbox link rendering and cart observer workflow.
- Mark Phase 4 complete in the refactoring plan and add Small coverage for the cart checker workflow.

## Validation
- `npm run fmt`
- `npm test`
- `npm run dep:check`
- `npm run build:chrome`

## Notes
- Reviewed with Claude Code; the main follow-up was missing Small coverage for `CartScrapboxChecker`, which is now added in this branch.
