### PR TITLE
[codex] fix cart checker render wait

### DIFF
--- a/src/__tests__/small/contentScript/cart-scrapbox-checker.test.ts
+++ b/src/__tests__/small/contentScript/cart-scrapbox-checker.test.ts
@@ -91,8 +91,9 @@ describe("CartScrapboxChecker", () => {
       document as unknown as Document;
     (globalThis as { window?: Window }).window = window as unknown as Window;
     (globalThis as { Node?: typeof Node }).Node = window.Node;
-    (globalThis as { MutationObserver?: typeof MutationObserver }).MutationObserver =
-      window.MutationObserver;
+    (
+      globalThis as { MutationObserver?: typeof MutationObserver }
+    ).MutationObserver = window.MutationObserver;
     return document;
   };
 
@@ -133,6 +134,14 @@ describe("CartScrapboxChecker", () => {
 
     mountChecker();
     await waitUntil(() => sendMessageMock().mock.calls.length > 0);
+    await waitUntil(() => {
+      const linksContainer = document.querySelector(
+        ".scrapbox-links-container",
+      );
+      return (
+        linksContainer?.textContent?.includes("もう買ってるかも:") ?? false
+      );
+    });
 
     expect(browser.runtime.sendMessage).toHaveBeenCalledWith({
       action: SearchBibliographyAction,


### PR DESCRIPTION
## Summary
- Wait for the cart Scrapbox links React render before asserting link text in the Small test.
- Keep the assertion aligned with the actual CI failure where the container existed but React had not populated its text yet.

## Root cause
The test waited for the Scrapbox search request, but `createRoot(...).render(...)` can commit asynchronously. CI occasionally read `.scrapbox-links-container.textContent` before React rendered `もう買ってるかも:`.

## Validation
- `npm run test:small -- --runInBand src/__tests__/small/contentScript/cart-scrapbox-checker.test.ts`
- `npm test`
- `npm run dep:check`
- Docker Node 24.11.1 / npm 11.6.4 CI-equivalent: `prettier --check`, `dep:check`, `test:small`
