### PR TITLE
Fix alert bar overflow with many candidates

### DIFF
--- a/src/organism/AlertBar.tsx
+++ b/src/organism/AlertBar.tsx
@@ -24,7 +24,7 @@ export function AlertBar(props: AlertBarProps) {
   return (
     <div className="bar alert">
       <div className="message">もう買ってるかも</div>
-      <div className="link">
+      <div className="link existingPages">
         {/* TODO: ボタンにする?*/}
         {existPages.map((page) => (
           <a href={page.url} key={page.url} target="_blank">
@@ -32,7 +32,7 @@ export function AlertBar(props: AlertBarProps) {
           </a>
         ))}
       </div>
-      <div className="link">
+      <div className="link createPageLink">
         <a href="#" onClick={handleClick}>
           {product.title} のページを作る
         </a>

--- a/src/organism/Bar.scss
+++ b/src/organism/Bar.scss
@@ -42,6 +42,20 @@ html {
     // ページを作るボタンが存在するのて、少し高さを確保
     height: 100px;
 
+    .message,
+    .createPageLink {
+        flex: 0 0 auto;
+    }
+
+    // 検索候補が多くても、ページ作成リンクの操作領域を確保する
+    .existingPages {
+        flex: 1 1 auto;
+        min-height: 0;
+        width: 100%;
+        overflow-y: auto;
+        text-align: center;
+    }
+
     .link {
         font-size: 15px;
         a {


### PR DESCRIPTION
## Summary

- keep the page creation link visible when Cosense search returns many candidate pages
- make only the existing-page candidate area vertically scrollable
- preserve the alert bar's existing fixed height and appearance

## Root cause

`AlertBar` rendered every existing-page candidate inside a fixed 100px-tall flex container. When the candidates wrapped onto multiple lines, they consumed or overlapped the space needed by the page creation link, making it difficult or impossible to click.

## User impact

Users can now scroll through a large candidate list while the page creation link remains available at the bottom of the alert bar.

## Validation

- `npm run fmt`
- `npm test` — 109 tests passed
- `npm run build:chrome`

Note: the generic `npm run build` requires `TARGET_BROWSER` and fails without it, so the browser-specific production build was used.
