### PR TITLE
Hide project name from candidate links

### DIFF
--- a/src/contentScript/BaseContentScript.tsx
+++ b/src/contentScript/BaseContentScript.tsx
@@ -131,7 +131,7 @@ export abstract class BaseContentScript {
     // メッセージを表示
     const existPages = result.pages.map((p) => {
       return {
-        name: "/" + projectName + "/" + p.title,
+        name: "/" + p.title,
         url: p.pageUrl,
       };
     });


### PR DESCRIPTION
## Summary

- omit the Cosense project name from existing-page candidate labels
- keep the candidate link destinations unchanged

## User impact

Candidate labels are now displayed as `/page title` instead of `/project/page title`, reducing visual noise in the alert bar.

## Validation

- `npm run fmt`
- `npm test` — 109 tests passed
- `npm run build:chrome`
