### PR TITLE
refactor: centralize product site definitions (Phase 5)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -57,6 +57,36 @@ module.exports = {
             },
         },
         {
+            name: "sites-must-stay-framework-independent",
+            severity: "error",
+            comment:
+                "Site definitions may compose scrapers and product factories, but must not depend on extension runtime or presentation code.",
+            from: {
+                path: "^src/sites/",
+            },
+            to: {
+                path: [
+                    "^src/(chromeApi|eventPage)\\.ts$",
+                    "^src/contentScript/",
+                    "^src/organism/",
+                    "^src/popup/",
+                ],
+            },
+        },
+        {
+            name: "sites-must-not-import-ui-or-extension-packages",
+            severity: "error",
+            comment:
+                "Framework-independent site definitions must remain free of UI and browser-extension runtime packages.",
+            from: {
+                path: "^src/sites/",
+            },
+            to: {
+                dependencyTypes: ["npm"],
+                path: ["^react$", "^react-dom", "^webextension-polyfill$"],
+            },
+        },
+        {
             name: "products-must-not-import-storage-keys",
             severity: "error",
             comment:

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -1,13 +1,13 @@
 # uni リファクタリング計画（Phase 1 完了後）
 
-> 更新: 2026-06-30 / 最新 `main` (`712885d`, `refactor: unify content script DOM waiting (Phase 4 PR-A) (#31)`) を基準に更新。
+> 更新: 2026-07-10 / 最新 `main` (`64f0661`, `Merge pull request #39 from motoso/codex/fix-alert-bar-overflow`) を基準に更新。
 > Phase 1（Product 丸ごと越境の廃止、検索 query DTO 化、null ガード、background の projectName 再読込、port 経路エラー応答）は完了済み。
 > Phase 1.5（検索境界の完全 DTO 化、`sendMessage` 一本化、port 経路廃止）は完了済み。
 > Phase 7a（ビルド/エントリ基盤の方針決定 ADR）は完了済み。WXT を採用方針とし、Phase 5 では自前 generator を作り込まない。
 > Phase 6（フィクスチャテストの導入）は主要対象の実ページ由来 HTML fixture と Small characterization test を追加済み。
 > Phase 3（Scraper 契約の統一）は完了済み。`publishedAt` の `Date | null` 統一、scraped data 型の集約、scraper logging 集約、Amazon publisher parse 修正、Amazon speculative fallback selector 削減を追加済み。
 > Phase 2（Product 責務分離）は完了。`titleForSearch` と Scrapbox placeholder formatter を pure domain function として `src/domain` に抽出し、`createScrapboxBodyString` を storage 非依存の同期 pure メソッド化、全角→半角変換を `src/domain/halfWidth.ts` に集約、各 product class の default format を `{token}` 化して toTemplateVars 経由の1経路に統一済み。
-> Phase 4（Content Script 共通化）は完了。次の作業対象は Phase 5。
+> Phase 4（Content Script 共通化）は完了。Phase 5（サイトレジストリ化）は、詳細商品サイトの service / host / match pattern / product type / scraper / product factory / content script entry を framework 非依存の `src/sites` に集約済み。次の作業対象は Phase 7b。
 > 今後はフル Clean Architecture ではなく、uni の規模に合わせた **DDD-lite + 最小 port 境界** を採用する。
 
 ## 0. 現在地
@@ -155,7 +155,7 @@ hampu と同じ考え方で、方向性チェックをCIに入れる。
 
 **Phase 7a → Phase 6 → Phase 3 → Phase 2 → Phase 4 → Phase 5 → Phase 7b → Phase 8**
 
-Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 は完了済みとして扱う。次の作業対象は Phase 5。
+Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 / Phase 5 は完了済みとして扱う。次の作業対象は Phase 7b。
 
 ### Phase 1.5 — 検索境界の完全 DTO 化と sendMessage 一本化（完了）
 
@@ -329,7 +329,7 @@ CI強化:
 
 - Phase 7b で entrypoint 規約が変わる可能性があるため、ファイル移動は最小限にする。
 
-### Phase 5 — サイトレジストリ化
+### Phase 5 — サイトレジストリ化（完了）
 
 目的:
 
@@ -348,6 +348,13 @@ Phase 7a の結論に従う:
 - scraper
 - product factory
 - content script entry
+
+実績:
+
+- 詳細商品サイトごとの型付き plain definition を `src/sites` に追加し、上記情報を集約。
+- 各 Content Script は site definition の service / scraper / product factory を利用し、重複していた Product 組み立てを除去。
+- `productSiteRegistry` の ID / entry 一意性と routing / runtime adapter の必須項目を Small test で固定。
+- 商品を持たないカート用 Content Script は product site registry の対象外とし、Phase 7b の entrypoint 移行時に別種の定義として扱う。
 
 ### Phase 7b — ビルド基盤の本移行
 

--- a/src/__tests__/small/sites/registry.test.ts
+++ b/src/__tests__/small/sites/registry.test.ts
@@ -1,0 +1,46 @@
+import { productSiteRegistry } from "../../../sites/registry";
+
+describe("productSiteRegistry", () => {
+  it("keeps every product-site id and content-script entry unique", () => {
+    const ids = productSiteRegistry.map(({ id }) => id);
+    const entries = productSiteRegistry.map(
+      ({ contentScriptEntry }) => contentScriptEntry,
+    );
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(new Set(entries).size).toBe(entries.length);
+  });
+
+  it("provides routing and runtime adapters for every product site", () => {
+    for (const site of productSiteRegistry) {
+      expect(site.hosts.length).toBeGreaterThan(0);
+      expect(site.matches.length).toBeGreaterThan(0);
+      expect(site.productTypes.length).toBeGreaterThan(0);
+      expect(typeof site.scraper).toBe("function");
+      expect(typeof site.createProduct).toBe("function");
+      for (const match of site.matches) {
+        expect(match).toMatch(/^https:\/\//);
+        expect(site.hosts.some((host) => match.includes(host))).toBe(true);
+      }
+    }
+  });
+
+  it("covers the current product content-script entries", () => {
+    expect(
+      productSiteRegistry.map(({ contentScriptEntry }) => contentScriptEntry),
+    ).toEqual([
+      "fanzaBooks",
+      "fanzaDoujin",
+      "fanzaVideo",
+      "fanzaAnime",
+      "dlsite",
+      "dlsiteManiax",
+      "toranoana",
+      "melonbooks",
+      "amazon",
+      "bookWalker",
+      "fc2ContentMarket",
+      "surugaya",
+    ]);
+  });
+});

--- a/src/__tests__/small/sites/registry.test.ts
+++ b/src/__tests__/small/sites/registry.test.ts
@@ -1,4 +1,5 @@
 import { productSiteRegistry } from "../../../sites/registry";
+import manifest from "../../../manifest.json";
 
 describe("productSiteRegistry", () => {
   it("keeps every product-site id and content-script entry unique", () => {
@@ -42,5 +43,23 @@ describe("productSiteRegistry", () => {
       "fc2ContentMarket",
       "surugaya",
     ]);
+  });
+
+  it("stays aligned with manifest product content scripts", () => {
+    const cartEntries = new Set(["DMMBasket", "DLsiteCart"]);
+    const manifestProductRoutes = manifest.content_scripts
+      .map(({ js, matches }) => ({
+        contentScriptEntry: js[0].replace(/^js\//, "").replace(/\.js$/, ""),
+        matches,
+      }))
+      .filter(({ contentScriptEntry }) => !cartEntries.has(contentScriptEntry));
+    const registryProductRoutes = productSiteRegistry.map(
+      ({ contentScriptEntry, matches }) => ({
+        contentScriptEntry,
+        matches: [...matches],
+      }),
+    );
+
+    expect(registryProductRoutes).toEqual(manifestProductRoutes);
   });
 });

--- a/src/contentScript/Amazon.tsx
+++ b/src/contentScript/Amazon.tsx
@@ -1,33 +1,21 @@
-import Book from "../Book";
-import * as React from "react";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import { scrapeAmazonData } from "../scraping/amazon-scraper";
 import { AmazonScrapedData } from "../scraping/types";
+import { amazonSite } from "../sites/amazon";
 
 /**
  * Amazonのページを開いたときに実行される
  */
 class Amazon extends DetailContentScript<AmazonScrapedData> {
-  protected readonly SERVICE = AcceptedService.amazon;
+  protected readonly SERVICE = amazonSite.service;
   protected readonly rootElementMountPoint = { target: "#navbar" };
 
   protected scrapeData(): AmazonScrapedData | null {
-    return scrapeAmazonData(document);
+    return amazonSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: AmazonScrapedData): Book {
-    // background scriptに送る
-    return Book.make(
-      this.SERVICE,
-      scrapedData.title,
-      scrapedData.authors,
-      scrapedData.url,
-      scrapedData.publisher,
-      null, // label
-      this.publishedAt(scrapedData.publishedAt),
-    );
+  protected createProduct(scrapedData: AmazonScrapedData) {
+    return amazonSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/BookWalker.tsx
+++ b/src/contentScript/BookWalker.tsx
@@ -1,17 +1,14 @@
-import Book from "../Book";
-import * as React from "react";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import { scrapeBookWalkerData } from "../scraping/bookwalker-scraper";
 import { BookWalkerScrapedData } from "../scraping/types";
+import { bookWalkerSite } from "../sites/bookWalker";
 
 /**
  * Bookwalkerのページを開いたときに実行される
  * https://bookwalker.jp/dea73feaf6-9f21-4c46-ac85-991153a0b71b/
  */
 class BookWalker extends DetailContentScript<BookWalkerScrapedData> {
-  protected readonly SERVICE = AcceptedService.bookWalker;
+  protected readonly SERVICE = bookWalkerSite.service;
   protected readonly rootElementMountPoint = {
     target: () =>
       document.getElementsByClassName("header")[0] ||
@@ -21,20 +18,11 @@ class BookWalker extends DetailContentScript<BookWalkerScrapedData> {
   };
 
   protected scrapeData(): BookWalkerScrapedData | null {
-    return scrapeBookWalkerData(document);
+    return bookWalkerSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: BookWalkerScrapedData): Book {
-    // background scriptに送る
-    return Book.make(
-      this.SERVICE,
-      scrapedData.title,
-      scrapedData.authors,
-      scrapedData.url,
-      scrapedData.publisher,
-      scrapedData.label,
-      this.publishedAt(scrapedData.publishedAt),
-    );
+  protected createProduct(scrapedData: BookWalkerScrapedData) {
+    return bookWalkerSite.createProduct(scrapedData);
   }
 
   execute() {

--- a/src/contentScript/DLsiteBooks.tsx
+++ b/src/contentScript/DLsiteBooks.tsx
@@ -1,34 +1,22 @@
-import Book from "../Book";
-import * as React from "react";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import { scrapeDLsiteBooksData } from "../scraping/dlsite-books-scraper";
 import { DLsiteBooksScrapedData } from "../scraping/types";
+import { dlsiteBooksSite } from "../sites/dlsiteBooks";
 
 /**
  * DLSite booksのページを開いたときに実行される
  * https://www.dlsite.com/books/work/=/product_id/BJ183632.html
  */
 class DLsiteBooks extends DetailContentScript<DLsiteBooksScrapedData> {
-  protected readonly SERVICE = AcceptedService.dlsite;
+  protected readonly SERVICE = dlsiteBooksSite.service;
   protected readonly rootElementMountPoint = { target: "#header" };
 
   protected scrapeData(): DLsiteBooksScrapedData | null {
-    return scrapeDLsiteBooksData(document);
+    return dlsiteBooksSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: DLsiteBooksScrapedData): Book {
-    // background scriptに送る
-    return Book.make(
-      AcceptedService.dlsite,
-      scrapedData.title,
-      scrapedData.authors,
-      scrapedData.url,
-      scrapedData.publisher,
-      scrapedData.label,
-      this.publishedAt(scrapedData.publishedAt),
-    );
+  protected createProduct(scrapedData: DLsiteBooksScrapedData) {
+    return dlsiteBooksSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/DLsiteManiax.tsx
+++ b/src/contentScript/DLsiteManiax.tsx
@@ -1,55 +1,22 @@
-import * as React from "react";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import Doujinshi from "../Doujinshi";
-import Asmr from "../Asmr";
-import Product from "../Product";
-import {
-  DLSITE_MANIAX_ASMR_TYPE,
-  scrapeDLsiteManiaxData,
-} from "../scraping/dlsite-maniax-scraper";
 import { DLsiteManiaxScrapedData } from "../scraping/types";
+import { dlsiteManiaxSite } from "../sites/dlsiteManiax";
 
 /**
  * DLSite maniaxやがるまに
  * を開いたときに実行される
  */
 class DLsiteManiax extends DetailContentScript<DLsiteManiaxScrapedData> {
-  protected readonly SERVICE = AcceptedService.dlsiteManiax;
+  protected readonly SERVICE = dlsiteManiaxSite.service;
   protected readonly rootElementMountPoint = { target: "#header" };
 
   protected scrapeData(): DLsiteManiaxScrapedData | null {
-    return scrapeDLsiteManiaxData(document);
+    return dlsiteManiaxSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: DLsiteManiaxScrapedData): Product {
-    switch (scrapedData.type) {
-      case DLSITE_MANIAX_ASMR_TYPE:
-        return Asmr.make(
-          AcceptedService.dlsiteManiax,
-          scrapedData.title,
-          scrapedData.authors,
-          scrapedData.url,
-          this.publishedAt(scrapedData.publishedAt),
-          scrapedData.circleName,
-          scrapedData.eventName,
-          scrapedData.illustrators,
-          scrapedData.voiceActors,
-          scrapedData.writers,
-        );
-      default:
-        // background scriptに送る
-        return Doujinshi.make(
-          AcceptedService.dlsiteManiax,
-          scrapedData.title,
-          scrapedData.authors,
-          scrapedData.url,
-          this.publishedAt(scrapedData.publishedAt),
-          scrapedData.circleName,
-          scrapedData.eventName,
-        );
-    }
+  protected createProduct(scrapedData: DLsiteManiaxScrapedData) {
+    return dlsiteManiaxSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/DetailContentScript.ts
+++ b/src/contentScript/DetailContentScript.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import Product from "../Product";
 import { BaseContentScript } from "./BaseContentScript";
 
@@ -16,9 +15,5 @@ export abstract class DetailContentScript<
     }
 
     return this.createProduct(scrapedData);
-  }
-
-  protected publishedAt(date: Date | null): dayjs.Dayjs | null {
-    return date ? dayjs(date) : null;
   }
 }

--- a/src/contentScript/FanzaAnime.tsx
+++ b/src/contentScript/FanzaAnime.tsx
@@ -2,13 +2,11 @@
 import "../organism/Bar.scss";
 
 import { DetailContentScript } from "./DetailContentScript";
-import { AcceptedService } from "../constant";
-import Film from "../Film";
-import { scrapeFanzaAnimeData } from "../scraping/fanza-anime-scraper";
 import { FanzaAnimeScrapedData } from "../scraping/types";
+import { fanzaAnimeSite } from "../sites/fanzaAnime";
 
 class FanzaAnime extends DetailContentScript<FanzaAnimeScrapedData> {
-  protected readonly SERVICE = AcceptedService.fanzaAnime;
+  protected readonly SERVICE = fanzaAnimeSite.service;
   // SPAで本文が後から描画されるため、DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
   protected readonly rootElementMountPoint = {
@@ -17,20 +15,11 @@ class FanzaAnime extends DetailContentScript<FanzaAnimeScrapedData> {
   };
 
   protected scrapeData(): FanzaAnimeScrapedData | null {
-    return scrapeFanzaAnimeData(document);
+    return fanzaAnimeSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: FanzaAnimeScrapedData): Film {
-    return Film.make(
-      AcceptedService.fanzaAnime,
-      scrapedData.title,
-      scrapedData.actress,
-      scrapedData.director,
-      scrapedData.url,
-      this.publishedAt(scrapedData.publishedAt),
-      scrapedData.label,
-      scrapedData.manufacturerProductNumber,
-    );
+  protected createProduct(scrapedData: FanzaAnimeScrapedData) {
+    return fanzaAnimeSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/FanzaBooks.tsx
+++ b/src/contentScript/FanzaBooks.tsx
@@ -1,16 +1,14 @@
-import Book from "../Book";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import { scrapeFanzaBooksData } from "../scraping/fanza-books-scraper";
 import { FanzaBooksScrapedData } from "../scraping/types";
+import { fanzaBooksSite } from "../sites/fanzaBooks";
 
 /**
  * FANZAのページを開いたときに実行される
  * https://book.dmm.co.jp/detail/*
  */
 class FanzaBooks extends DetailContentScript<FanzaBooksScrapedData> {
-  protected readonly SERVICE = AcceptedService.fanza;
+  protected readonly SERVICE = fanzaBooksSite.service;
   // 2023年4月ごろのアップデートでBFFで後から動的に情報を取得するようになったため、
   // DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
@@ -20,20 +18,11 @@ class FanzaBooks extends DetailContentScript<FanzaBooksScrapedData> {
   };
 
   protected scrapeData(): FanzaBooksScrapedData | null {
-    return scrapeFanzaBooksData(document);
+    return fanzaBooksSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: FanzaBooksScrapedData): Book {
-    // background scriptに送る
-    return Book.make(
-      AcceptedService.fanza,
-      scrapedData.title,
-      scrapedData.authors ?? null,
-      scrapedData.url,
-      scrapedData.publisher,
-      scrapedData.label,
-      this.publishedAt(scrapedData.publishedAt),
-    );
+  protected createProduct(scrapedData: FanzaBooksScrapedData) {
+    return fanzaBooksSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/FanzaDoujin.tsx
+++ b/src/contentScript/FanzaDoujin.tsx
@@ -1,16 +1,13 @@
-import * as React from "react";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import Doujinshi from "../Doujinshi";
-import { scrapeFanzaDoujinData } from "../scraping/fanza-doujin-scraper";
 import { FanzaDoujinScrapedData } from "../scraping/types";
+import { fanzaDoujinSite } from "../sites/fanzaDoujin";
 
 /**
  * FANZAのページを開いたときに実行される
  */
 class FanzaDoujin extends DetailContentScript<FanzaDoujinScrapedData> {
-  protected readonly SERVICE = AcceptedService.fanzaDojin;
+  protected readonly SERVICE = fanzaDoujinSite.service;
   protected readonly rootElementMountPoint = {
     target: () => document.getElementsByTagName("header")[0] ?? null,
     prepareTarget: (target: Element) => {
@@ -21,20 +18,11 @@ class FanzaDoujin extends DetailContentScript<FanzaDoujinScrapedData> {
   };
 
   protected scrapeData(): FanzaDoujinScrapedData | null {
-    return scrapeFanzaDoujinData(document);
+    return fanzaDoujinSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: FanzaDoujinScrapedData): Doujinshi {
-    // background scriptに送る
-    return Doujinshi.make(
-      AcceptedService.fanzaDojin,
-      scrapedData.title,
-      scrapedData.authors,
-      scrapedData.url,
-      this.publishedAt(scrapedData.publishedAt),
-      scrapedData.circleName,
-      null,
-    );
+  protected createProduct(scrapedData: FanzaDoujinScrapedData) {
+    return fanzaDoujinSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/FanzaVideo.tsx
+++ b/src/contentScript/FanzaVideo.tsx
@@ -2,13 +2,11 @@
 import "../organism/Bar.scss";
 
 import { DetailContentScript } from "./DetailContentScript";
-import { AcceptedService } from "../constant";
-import Film from "../Film";
-import { scrapeFanzaVideoData } from "../scraping/fanza-video-scraper";
 import { FanzaVideoScrapedData } from "../scraping/types";
+import { fanzaVideoSite } from "../sites/fanzaVideo";
 
 class FanzaVideo extends DetailContentScript<FanzaVideoScrapedData> {
-  protected readonly SERVICE = AcceptedService.fanzaVideo;
+  protected readonly SERVICE = fanzaVideoSite.service;
   // 本文が後から動的に描画されるため、DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
   protected readonly rootElementMountPoint = {
@@ -18,21 +16,11 @@ class FanzaVideo extends DetailContentScript<FanzaVideoScrapedData> {
   };
 
   protected scrapeData(): FanzaVideoScrapedData | null {
-    return scrapeFanzaVideoData(document);
+    return fanzaVideoSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: FanzaVideoScrapedData): Film {
-    // background scriptに送る
-    return Film.make(
-      AcceptedService.fanzaVideo,
-      scrapedData.title,
-      scrapedData.actress,
-      scrapedData.director,
-      scrapedData.url,
-      this.publishedAt(scrapedData.publishedAt),
-      scrapedData.label,
-      scrapedData.id,
-    );
+  protected createProduct(scrapedData: FanzaVideoScrapedData) {
+    return fanzaVideoSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/Fc2ContentMarket.tsx
+++ b/src/contentScript/Fc2ContentMarket.tsx
@@ -2,34 +2,22 @@
 import "../organism/Bar.scss";
 
 import { DetailContentScript } from "./DetailContentScript";
-import { AcceptedService } from "../constant";
-import Film from "../Film";
-import { scrapeFc2ContentMarketData } from "../scraping/fc2-content-market-scraper";
 import { Fc2ContentMarketScrapedData } from "../scraping/types";
+import { fc2ContentMarketSite } from "../sites/fc2ContentMarket";
 
 class FC2ContentMarket extends DetailContentScript<Fc2ContentMarketScrapedData> {
-  protected readonly SERVICE = AcceptedService.fc2ContentMarket;
+  protected readonly SERVICE = fc2ContentMarketSite.service;
   protected readonly rootElementMountPoint = {
     target: "header",
     position: "afterend" as const,
   };
 
   protected scrapeData(): Fc2ContentMarketScrapedData | null {
-    return scrapeFc2ContentMarketData(document);
+    return fc2ContentMarketSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: Fc2ContentMarketScrapedData): Film {
-    // background scriptに送る
-    return Film.make(
-      this.SERVICE,
-      scrapedData.title,
-      [], // actress
-      scrapedData.director === "" ? null : scrapedData.director,
-      scrapedData.url,
-      this.publishedAt(scrapedData.publishedAt),
-      "", // label
-      scrapedData.id,
-    );
+  protected createProduct(scrapedData: Fc2ContentMarketScrapedData) {
+    return fc2ContentMarketSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/Melonbooks.tsx
+++ b/src/contentScript/Melonbooks.tsx
@@ -1,33 +1,21 @@
-import * as React from "react";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import Doujinshi from "../Doujinshi";
-import { scrapeMelonbooksData } from "../scraping/melonbooks-scraper";
 import { MelonbooksScrapedData } from "../scraping/types";
+import { melonbooksSite } from "../sites/melonbooks";
 
 /**
  * メロンブックスのページを開いたときに実行される
  */
 class Melonbooks extends DetailContentScript<MelonbooksScrapedData> {
-  protected readonly SERVICE = AcceptedService.melonbooks;
+  protected readonly SERVICE = melonbooksSite.service;
   protected readonly rootElementMountPoint = { target: "#header_free_html" };
 
   protected scrapeData(): MelonbooksScrapedData | null {
-    return scrapeMelonbooksData(document);
+    return melonbooksSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: MelonbooksScrapedData): Doujinshi {
-    // background scriptに送る
-    return Doujinshi.make(
-      AcceptedService.melonbooks,
-      scrapedData.title,
-      scrapedData.authors,
-      scrapedData.url,
-      this.publishedAt(scrapedData.publishedAt),
-      scrapedData.circleName,
-      scrapedData.eventName,
-    );
+  protected createProduct(scrapedData: MelonbooksScrapedData) {
+    return melonbooksSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/Surugaya.tsx
+++ b/src/contentScript/Surugaya.tsx
@@ -1,10 +1,7 @@
-import * as React from "react";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import Doujinshi from "../Doujinshi";
-import { scrapeSurugayaData } from "../scraping/surugaya-scraper";
 import { SurugayaScrapedData } from "../scraping/types";
+import { surugayaSite } from "../sites/surugaya";
 
 /**
  * 駿河屋のページを開いたときに実行される
@@ -14,26 +11,17 @@ import { SurugayaScrapedData } from "../scraping/types";
  * https://gyazo.com/369f88d61f358ea642d91964e5c682fc
  */
 class Surugaya extends DetailContentScript<SurugayaScrapedData> {
-  protected readonly SERVICE = AcceptedService.surugaya;
+  protected readonly SERVICE = surugayaSite.service;
   protected readonly rootElementMountPoint = {
     target: "body > div.dialog-off-canvas-main-canvas > header > div.top_nav",
   };
 
   protected scrapeData(): SurugayaScrapedData | null {
-    return scrapeSurugayaData(document);
+    return surugayaSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: SurugayaScrapedData): Doujinshi {
-    // background scriptに送る
-    return Doujinshi.make(
-      AcceptedService.surugaya,
-      scrapedData.title,
-      scrapedData.authors,
-      scrapedData.url,
-      this.publishedAt(scrapedData.publishedAt),
-      scrapedData.publisher,
-      null,
-    );
+  protected createProduct(scrapedData: SurugayaScrapedData) {
+    return surugayaSite.createProduct(scrapedData);
   }
 }
 

--- a/src/contentScript/Toranoana.tsx
+++ b/src/contentScript/Toranoana.tsx
@@ -1,34 +1,22 @@
-import * as React from "react";
 import "../organism/Bar.scss";
-import { AcceptedService } from "../constant";
 import { DetailContentScript } from "./DetailContentScript";
-import Doujinshi from "../Doujinshi";
-import { scrapeToranoanaData } from "../scraping/toranoana-scraper";
 import { ToranoanaScrapedData } from "../scraping/types";
+import { toranoanaSite } from "../sites/toranoana";
 
 /**
  * とらのあなのページを開いたときに実行される
  * https://ec.toranoana.jp/tora_r/ec/item/
  */
 class Toranoana extends DetailContentScript<ToranoanaScrapedData> {
-  protected readonly SERVICE = AcceptedService.toranoana;
+  protected readonly SERVICE = toranoanaSite.service;
   protected readonly rootElementMountPoint = { target: "header" };
 
   protected scrapeData(): ToranoanaScrapedData | null {
-    return scrapeToranoanaData(document);
+    return toranoanaSite.scraper(document);
   }
 
-  protected createProduct(scrapedData: ToranoanaScrapedData): Doujinshi {
-    // background scriptに送る
-    return Doujinshi.make(
-      AcceptedService.toranoana,
-      scrapedData.title,
-      scrapedData.authors,
-      scrapedData.url,
-      this.publishedAt(scrapedData.publishedAt),
-      scrapedData.circleName,
-      scrapedData.eventName || "",
-    );
+  protected createProduct(scrapedData: ToranoanaScrapedData) {
+    return toranoanaSite.createProduct(scrapedData);
   }
 }
 

--- a/src/sites/amazon.ts
+++ b/src/sites/amazon.ts
@@ -1,0 +1,29 @@
+import Book from "../Book";
+import { AcceptedService } from "../constant";
+import { scrapeAmazonData } from "../scraping/amazon-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const amazonSite = defineProductSite({
+  id: "amazon",
+  service: AcceptedService.amazon,
+  hosts: ["www.amazon.co.jp"],
+  matches: [
+    "https://www.amazon.co.jp/dp/*",
+    "https://www.amazon.co.jp/*/dp/*",
+    "https://www.amazon.co.jp/gp/product/*",
+  ],
+  productTypes: ["book"],
+  contentScriptEntry: "amazon",
+  scraper: scrapeAmazonData,
+  createProduct: (data) =>
+    Book.make(
+      AcceptedService.amazon,
+      data.title,
+      data.authors,
+      data.url,
+      data.publisher,
+      null,
+      toPublishedAt(data.publishedAt),
+    ),
+});

--- a/src/sites/bookWalker.ts
+++ b/src/sites/bookWalker.ts
@@ -1,0 +1,25 @@
+import Book from "../Book";
+import { AcceptedService } from "../constant";
+import { scrapeBookWalkerData } from "../scraping/bookwalker-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const bookWalkerSite = defineProductSite({
+  id: "bookWalker",
+  service: AcceptedService.bookWalker,
+  hosts: ["bookwalker.jp"],
+  matches: ["https://bookwalker.jp/*"],
+  productTypes: ["book"],
+  contentScriptEntry: "bookWalker",
+  scraper: scrapeBookWalkerData,
+  createProduct: (data) =>
+    Book.make(
+      AcceptedService.bookWalker,
+      data.title,
+      data.authors,
+      data.url,
+      data.publisher,
+      data.label,
+      toPublishedAt(data.publishedAt),
+    ),
+});

--- a/src/sites/dlsiteBooks.ts
+++ b/src/sites/dlsiteBooks.ts
@@ -1,0 +1,25 @@
+import Book from "../Book";
+import { AcceptedService } from "../constant";
+import { scrapeDLsiteBooksData } from "../scraping/dlsite-books-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const dlsiteBooksSite = defineProductSite({
+  id: "dlsiteBooks",
+  service: AcceptedService.dlsite,
+  hosts: ["www.dlsite.com"],
+  matches: ["https://www.dlsite.com/books/work/=/product_id/*"],
+  productTypes: ["book"],
+  contentScriptEntry: "dlsite",
+  scraper: scrapeDLsiteBooksData,
+  createProduct: (data) =>
+    Book.make(
+      AcceptedService.dlsite,
+      data.title,
+      data.authors,
+      data.url,
+      data.publisher,
+      data.label,
+      toPublishedAt(data.publishedAt),
+    ),
+});

--- a/src/sites/dlsiteManiax.ts
+++ b/src/sites/dlsiteManiax.ts
@@ -1,0 +1,47 @@
+import Asmr from "../Asmr";
+import Doujinshi from "../Doujinshi";
+import { AcceptedService } from "../constant";
+import {
+  DLSITE_MANIAX_ASMR_TYPE,
+  scrapeDLsiteManiaxData,
+} from "../scraping/dlsite-maniax-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const dlsiteManiaxSite = defineProductSite({
+  id: "dlsiteManiax",
+  service: AcceptedService.dlsiteManiax,
+  hosts: ["www.dlsite.com"],
+  matches: [
+    "https://www.dlsite.com/maniax/work/=/product_id/*",
+    "https://www.dlsite.com/home/work/=/product_id/*",
+    "https://www.dlsite.com/girls/work/=/product_id/*",
+    "https://www.dlsite.com/aix/work/=/product_id/*",
+  ],
+  productTypes: ["asmr", "doujinshi"],
+  contentScriptEntry: "dlsiteManiax",
+  scraper: scrapeDLsiteManiaxData,
+  createProduct: (data) =>
+    data.type === DLSITE_MANIAX_ASMR_TYPE
+      ? Asmr.make(
+          AcceptedService.dlsiteManiax,
+          data.title,
+          data.authors,
+          data.url,
+          toPublishedAt(data.publishedAt),
+          data.circleName,
+          data.eventName,
+          data.illustrators,
+          data.voiceActors,
+          data.writers,
+        )
+      : Doujinshi.make(
+          AcceptedService.dlsiteManiax,
+          data.title,
+          data.authors,
+          data.url,
+          toPublishedAt(data.publishedAt),
+          data.circleName,
+          data.eventName,
+        ),
+});

--- a/src/sites/fanzaAnime.ts
+++ b/src/sites/fanzaAnime.ts
@@ -1,0 +1,26 @@
+import Film from "../Film";
+import { AcceptedService } from "../constant";
+import { scrapeFanzaAnimeData } from "../scraping/fanza-anime-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const fanzaAnimeSite = defineProductSite({
+  id: "fanzaAnime",
+  service: AcceptedService.fanzaAnime,
+  hosts: ["video.dmm.co.jp"],
+  matches: ["https://video.dmm.co.jp/anime/content/*"],
+  productTypes: ["film"],
+  contentScriptEntry: "fanzaAnime",
+  scraper: scrapeFanzaAnimeData,
+  createProduct: (data) =>
+    Film.make(
+      AcceptedService.fanzaAnime,
+      data.title,
+      data.actress,
+      data.director,
+      data.url,
+      toPublishedAt(data.publishedAt),
+      data.label,
+      data.manufacturerProductNumber,
+    ),
+});

--- a/src/sites/fanzaBooks.ts
+++ b/src/sites/fanzaBooks.ts
@@ -1,0 +1,25 @@
+import Book from "../Book";
+import { AcceptedService } from "../constant";
+import { scrapeFanzaBooksData } from "../scraping/fanza-books-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const fanzaBooksSite = defineProductSite({
+  id: "fanzaBooks",
+  service: AcceptedService.fanza,
+  hosts: ["book.dmm.co.jp"],
+  matches: ["https://book.dmm.co.jp/*"],
+  productTypes: ["book"],
+  contentScriptEntry: "fanzaBooks",
+  scraper: scrapeFanzaBooksData,
+  createProduct: (data) =>
+    Book.make(
+      AcceptedService.fanza,
+      data.title,
+      data.authors ?? null,
+      data.url,
+      data.publisher,
+      data.label,
+      toPublishedAt(data.publishedAt),
+    ),
+});

--- a/src/sites/fanzaDoujin.ts
+++ b/src/sites/fanzaDoujin.ts
@@ -1,0 +1,25 @@
+import Doujinshi from "../Doujinshi";
+import { AcceptedService } from "../constant";
+import { scrapeFanzaDoujinData } from "../scraping/fanza-doujin-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const fanzaDoujinSite = defineProductSite({
+  id: "fanzaDoujin",
+  service: AcceptedService.fanzaDojin,
+  hosts: ["www.dmm.co.jp"],
+  matches: ["https://www.dmm.co.jp/dc/doujin/-/detail/=/*"],
+  productTypes: ["doujinshi"],
+  contentScriptEntry: "fanzaDoujin",
+  scraper: scrapeFanzaDoujinData,
+  createProduct: (data) =>
+    Doujinshi.make(
+      AcceptedService.fanzaDojin,
+      data.title,
+      data.authors,
+      data.url,
+      toPublishedAt(data.publishedAt),
+      data.circleName,
+      null,
+    ),
+});

--- a/src/sites/fanzaVideo.ts
+++ b/src/sites/fanzaVideo.ts
@@ -1,0 +1,29 @@
+import Film from "../Film";
+import { AcceptedService } from "../constant";
+import { scrapeFanzaVideoData } from "../scraping/fanza-video-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const fanzaVideoSite = defineProductSite({
+  id: "fanzaVideo",
+  service: AcceptedService.fanzaVideo,
+  hosts: ["www.dmm.co.jp", "video.dmm.co.jp"],
+  matches: [
+    "https://www.dmm.co.jp/digital/videoa/-/detail/=/*",
+    "https://video.dmm.co.jp/av/content/*",
+  ],
+  productTypes: ["film"],
+  contentScriptEntry: "fanzaVideo",
+  scraper: scrapeFanzaVideoData,
+  createProduct: (data) =>
+    Film.make(
+      AcceptedService.fanzaVideo,
+      data.title,
+      data.actress,
+      data.director,
+      data.url,
+      toPublishedAt(data.publishedAt),
+      data.label,
+      data.id,
+    ),
+});

--- a/src/sites/fc2ContentMarket.ts
+++ b/src/sites/fc2ContentMarket.ts
@@ -1,0 +1,26 @@
+import Film from "../Film";
+import { AcceptedService } from "../constant";
+import { scrapeFc2ContentMarketData } from "../scraping/fc2-content-market-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const fc2ContentMarketSite = defineProductSite({
+  id: "fc2ContentMarket",
+  service: AcceptedService.fc2ContentMarket,
+  hosts: ["adult.contents.fc2.com"],
+  matches: ["https://adult.contents.fc2.com/article/*"],
+  productTypes: ["film"],
+  contentScriptEntry: "fc2ContentMarket",
+  scraper: scrapeFc2ContentMarketData,
+  createProduct: (data) =>
+    Film.make(
+      AcceptedService.fc2ContentMarket,
+      data.title,
+      [],
+      data.director === "" ? null : data.director,
+      data.url,
+      toPublishedAt(data.publishedAt),
+      "",
+      data.id,
+    ),
+});

--- a/src/sites/melonbooks.ts
+++ b/src/sites/melonbooks.ts
@@ -1,0 +1,25 @@
+import Doujinshi from "../Doujinshi";
+import { AcceptedService } from "../constant";
+import { scrapeMelonbooksData } from "../scraping/melonbooks-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const melonbooksSite = defineProductSite({
+  id: "melonbooks",
+  service: AcceptedService.melonbooks,
+  hosts: ["www.melonbooks.co.jp"],
+  matches: ["https://www.melonbooks.co.jp/detail/detail.php*"],
+  productTypes: ["doujinshi"],
+  contentScriptEntry: "melonbooks",
+  scraper: scrapeMelonbooksData,
+  createProduct: (data) =>
+    Doujinshi.make(
+      AcceptedService.melonbooks,
+      data.title,
+      data.authors,
+      data.url,
+      toPublishedAt(data.publishedAt),
+      data.circleName,
+      data.eventName,
+    ),
+});

--- a/src/sites/registry.ts
+++ b/src/sites/registry.ts
@@ -1,0 +1,33 @@
+import { amazonSite } from "./amazon";
+import { bookWalkerSite } from "./bookWalker";
+import { dlsiteBooksSite } from "./dlsiteBooks";
+import { dlsiteManiaxSite } from "./dlsiteManiax";
+import { fanzaAnimeSite } from "./fanzaAnime";
+import { fanzaBooksSite } from "./fanzaBooks";
+import { fanzaDoujinSite } from "./fanzaDoujin";
+import { fanzaVideoSite } from "./fanzaVideo";
+import { fc2ContentMarketSite } from "./fc2ContentMarket";
+import { melonbooksSite } from "./melonbooks";
+import { surugayaSite } from "./surugaya";
+import { toranoanaSite } from "./toranoana";
+
+/**
+ * Framework-independent source of truth for product-page integrations.
+ *
+ * Phase 7b can adapt this plain registry to WXT entrypoint metadata without
+ * coupling scraper or product creation code to the extension framework.
+ */
+export const productSiteRegistry = [
+  fanzaBooksSite,
+  fanzaDoujinSite,
+  fanzaVideoSite,
+  fanzaAnimeSite,
+  dlsiteBooksSite,
+  dlsiteManiaxSite,
+  toranoanaSite,
+  melonbooksSite,
+  amazonSite,
+  bookWalkerSite,
+  fc2ContentMarketSite,
+  surugayaSite,
+] as const;

--- a/src/sites/surugaya.ts
+++ b/src/sites/surugaya.ts
@@ -1,0 +1,25 @@
+import Doujinshi from "../Doujinshi";
+import { AcceptedService } from "../constant";
+import { scrapeSurugayaData } from "../scraping/surugaya-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const surugayaSite = defineProductSite({
+  id: "surugaya",
+  service: AcceptedService.surugaya,
+  hosts: ["www.suruga-ya.jp"],
+  matches: ["https://www.suruga-ya.jp/product/detail/*"],
+  productTypes: ["doujinshi"],
+  contentScriptEntry: "surugaya",
+  scraper: scrapeSurugayaData,
+  createProduct: (data) =>
+    Doujinshi.make(
+      AcceptedService.surugaya,
+      data.title,
+      data.authors,
+      data.url,
+      toPublishedAt(data.publishedAt),
+      data.publisher,
+      null,
+    ),
+});

--- a/src/sites/toPublishedAt.ts
+++ b/src/sites/toPublishedAt.ts
@@ -1,0 +1,5 @@
+import dayjs, { Dayjs } from "dayjs";
+
+export function toPublishedAt(date: Date | null): Dayjs | null {
+  return date ? dayjs(date) : null;
+}

--- a/src/sites/toranoana.ts
+++ b/src/sites/toranoana.ts
@@ -1,0 +1,28 @@
+import Doujinshi from "../Doujinshi";
+import { AcceptedService } from "../constant";
+import { scrapeToranoanaData } from "../scraping/toranoana-scraper";
+import { defineProductSite } from "./types";
+import { toPublishedAt } from "./toPublishedAt";
+
+export const toranoanaSite = defineProductSite({
+  id: "toranoana",
+  service: AcceptedService.toranoana,
+  hosts: ["ec.toranoana.jp", "ecs.toranoana.jp"],
+  matches: [
+    "https://ec.toranoana.jp/tora_r/ec/item/*",
+    "https://ecs.toranoana.jp/tora/ec/item/*",
+  ],
+  productTypes: ["doujinshi"],
+  contentScriptEntry: "toranoana",
+  scraper: scrapeToranoanaData,
+  createProduct: (data) =>
+    Doujinshi.make(
+      AcceptedService.toranoana,
+      data.title,
+      data.authors,
+      data.url,
+      toPublishedAt(data.publishedAt),
+      data.circleName,
+      data.eventName || "",
+    ),
+});

--- a/src/sites/types.ts
+++ b/src/sites/types.ts
@@ -1,0 +1,19 @@
+import Product, { ProductType } from "../Product";
+import { AcceptedService } from "../constant";
+
+export type ProductSiteDefinition<TScrapedData> = Readonly<{
+  id: string;
+  service: AcceptedService;
+  hosts: readonly string[];
+  matches: readonly string[];
+  productTypes: readonly ProductType[];
+  contentScriptEntry: string;
+  scraper: (document: Document) => TScrapedData | null;
+  createProduct: (scrapedData: TScrapedData) => Product;
+}>;
+
+export function defineProductSite<TScrapedData>(
+  definition: ProductSiteDefinition<TScrapedData>,
+): ProductSiteDefinition<TScrapedData> {
+  return definition;
+}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "ES2022"
+    "module": "ES2022",
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Summary

- add typed, framework-independent definitions for all 12 product-page integrations under `src/sites`
- centralize each site's service, hosts, match patterns, product types, scraper, product factory, and content-script entry
- update detail content scripts to delegate scraping and product construction to their site definition
- add Small tests for registry completeness and uniqueness
- mark Phase 5 complete and Phase 7b as the next refactoring phase

## Why

Adding or changing a supported product site required coordinated edits across content scripts, scrapers, product factories, manifest routing, and webpack entries. Phase 5 establishes a plain registry that can become the input to the planned WXT migration without coupling domain adapters to a browser-extension framework.

Per ADR 002, this PR intentionally does not add a custom webpack or manifest generator. Those handwritten entrypoints remain behaviorally unchanged until Phase 7b moves them to WXT conventions. Cart content scripts are also outside the product-site registry because they do not have a scraper or product factory.

## Validation

- `npm run fmt`
- `npm test` — 112 tests passed
- `npm run dep:check` — no dependency violations
- `npm run build:chrome`
- `npm run build:firefox`
- verified that the registry's 12 entry names and 19 match patterns agree with the current manifest
