### PR TITLE
refactor: remove unused SERVICE from content scripts

### DIFF
--- a/src/__tests__/small/contentScript/base-content-script-message.test.ts
+++ b/src/__tests__/small/contentScript/base-content-script-message.test.ts
@@ -16,7 +16,6 @@ import Product from "../../../Product";
 import { SearchBibliographyAction } from "../../../scrapbox/searchDtos";
 
 class TestContentScript extends BaseContentScript {
-  protected readonly SERVICE = AcceptedService.fanza;
   public createdBars = 0;
 
   constructor(private readonly product: Product | null) {
@@ -33,7 +32,6 @@ class TestContentScript extends BaseContentScript {
 }
 
 class MountTestContentScript extends BaseContentScript {
-  protected readonly SERVICE = AcceptedService.fanza;
 
   protected scrape(): Product | null {
     return null;
@@ -57,7 +55,6 @@ class MountTestContentScript extends BaseContentScript {
 }
 
 class DeclarativeMountTestContentScript extends BaseContentScript {
-  protected readonly SERVICE = AcceptedService.fanza;
   protected readonly rootElementMountPoint = {
     target: "#header",
     position: "afterend" as const,
@@ -73,7 +70,6 @@ class DeclarativeMountTestContentScript extends BaseContentScript {
 }
 
 class DetailTestContentScript extends DetailContentScript<{ title: string }> {
-  protected readonly SERVICE = AcceptedService.fanza;
   protected readonly rootElementMountPoint = { target: "body" };
 
   constructor(private readonly scrapedData: { title: string } | null) {
@@ -238,7 +234,6 @@ describe("動的描画サイト (waitForDynamicContent)", () => {
   });
 
   class DynamicScript extends BaseContentScript {
-    protected readonly SERVICE = AcceptedService.fanza;
     protected readonly waitForDynamicContent = true;
     protected readonly scrapeTimeoutMs = 50;
 

--- a/src/contentScript/Amazon.tsx
+++ b/src/contentScript/Amazon.tsx
@@ -7,7 +7,6 @@ import { amazonSite } from "../sites/amazon";
  * Amazonのページを開いたときに実行される
  */
 class Amazon extends DetailContentScript<AmazonScrapedData> {
-  protected readonly SERVICE = amazonSite.service;
   protected readonly rootElementMountPoint = { target: "#navbar" };
 
   protected scrapeData(): AmazonScrapedData | null {

--- a/src/contentScript/BaseContentScript.tsx
+++ b/src/contentScript/BaseContentScript.tsx
@@ -1,4 +1,3 @@
-import { AcceptedService } from "../constant";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { CreatePageBar } from "../organism/CreatePageBar";
@@ -26,9 +25,6 @@ type RootElementMountPoint = {
  */
 export abstract class BaseContentScript {
   protected readonly ROOT_ELEM = "uniBarRoot";
-  // これらは必ず実装してください
-  protected readonly SERVICE: AcceptedService;
-
   /**
    * BFF / SPA で本文が後から描画されるサイトは true にする。
    * true の場合、即時 scrape に失敗しても DOM の変化を監視して再 scrape する。

--- a/src/contentScript/BookWalker.tsx
+++ b/src/contentScript/BookWalker.tsx
@@ -8,7 +8,6 @@ import { bookWalkerSite } from "../sites/bookWalker";
  * https://bookwalker.jp/dea73feaf6-9f21-4c46-ac85-991153a0b71b/
  */
 class BookWalker extends DetailContentScript<BookWalkerScrapedData> {
-  protected readonly SERVICE = bookWalkerSite.service;
   protected readonly rootElementMountPoint = {
     target: () =>
       document.getElementsByClassName("header")[0] ||

--- a/src/contentScript/DLsiteBooks.tsx
+++ b/src/contentScript/DLsiteBooks.tsx
@@ -8,7 +8,6 @@ import { dlsiteBooksSite } from "../sites/dlsiteBooks";
  * https://www.dlsite.com/books/work/=/product_id/BJ183632.html
  */
 class DLsiteBooks extends DetailContentScript<DLsiteBooksScrapedData> {
-  protected readonly SERVICE = dlsiteBooksSite.service;
   protected readonly rootElementMountPoint = { target: "#header" };
 
   protected scrapeData(): DLsiteBooksScrapedData | null {

--- a/src/contentScript/DLsiteManiax.tsx
+++ b/src/contentScript/DLsiteManiax.tsx
@@ -8,7 +8,6 @@ import { dlsiteManiaxSite } from "../sites/dlsiteManiax";
  * を開いたときに実行される
  */
 class DLsiteManiax extends DetailContentScript<DLsiteManiaxScrapedData> {
-  protected readonly SERVICE = dlsiteManiaxSite.service;
   protected readonly rootElementMountPoint = { target: "#header" };
 
   protected scrapeData(): DLsiteManiaxScrapedData | null {

--- a/src/contentScript/FanzaAnime.tsx
+++ b/src/contentScript/FanzaAnime.tsx
@@ -6,7 +6,6 @@ import { FanzaAnimeScrapedData } from "../scraping/types";
 import { fanzaAnimeSite } from "../sites/fanzaAnime";
 
 class FanzaAnime extends DetailContentScript<FanzaAnimeScrapedData> {
-  protected readonly SERVICE = fanzaAnimeSite.service;
   // SPAで本文が後から描画されるため、DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
   protected readonly rootElementMountPoint = {

--- a/src/contentScript/FanzaBooks.tsx
+++ b/src/contentScript/FanzaBooks.tsx
@@ -8,7 +8,6 @@ import { fanzaBooksSite } from "../sites/fanzaBooks";
  * https://book.dmm.co.jp/detail/*
  */
 class FanzaBooks extends DetailContentScript<FanzaBooksScrapedData> {
-  protected readonly SERVICE = fanzaBooksSite.service;
   // 2023年4月ごろのアップデートでBFFで後から動的に情報を取得するようになったため、
   // DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;

--- a/src/contentScript/FanzaDoujin.tsx
+++ b/src/contentScript/FanzaDoujin.tsx
@@ -7,7 +7,6 @@ import { fanzaDoujinSite } from "../sites/fanzaDoujin";
  * FANZAのページを開いたときに実行される
  */
 class FanzaDoujin extends DetailContentScript<FanzaDoujinScrapedData> {
-  protected readonly SERVICE = fanzaDoujinSite.service;
   protected readonly rootElementMountPoint = {
     target: () => document.getElementsByTagName("header")[0] ?? null,
     prepareTarget: (target: Element) => {

--- a/src/contentScript/FanzaVideo.tsx
+++ b/src/contentScript/FanzaVideo.tsx
@@ -6,7 +6,6 @@ import { FanzaVideoScrapedData } from "../scraping/types";
 import { fanzaVideoSite } from "../sites/fanzaVideo";
 
 class FanzaVideo extends DetailContentScript<FanzaVideoScrapedData> {
-  protected readonly SERVICE = fanzaVideoSite.service;
   // 本文が後から動的に描画されるため、DOMの変化を待って再scrapeする。
   protected readonly waitForDynamicContent = true;
   protected readonly rootElementMountPoint = {

--- a/src/contentScript/Fc2ContentMarket.tsx
+++ b/src/contentScript/Fc2ContentMarket.tsx
@@ -6,7 +6,6 @@ import { Fc2ContentMarketScrapedData } from "../scraping/types";
 import { fc2ContentMarketSite } from "../sites/fc2ContentMarket";
 
 class FC2ContentMarket extends DetailContentScript<Fc2ContentMarketScrapedData> {
-  protected readonly SERVICE = fc2ContentMarketSite.service;
   protected readonly rootElementMountPoint = {
     target: "header",
     position: "afterend" as const,

--- a/src/contentScript/Melonbooks.tsx
+++ b/src/contentScript/Melonbooks.tsx
@@ -7,7 +7,6 @@ import { melonbooksSite } from "../sites/melonbooks";
  * メロンブックスのページを開いたときに実行される
  */
 class Melonbooks extends DetailContentScript<MelonbooksScrapedData> {
-  protected readonly SERVICE = melonbooksSite.service;
   protected readonly rootElementMountPoint = { target: "#header_free_html" };
 
   protected scrapeData(): MelonbooksScrapedData | null {

--- a/src/contentScript/Surugaya.tsx
+++ b/src/contentScript/Surugaya.tsx
@@ -11,7 +11,6 @@ import { surugayaSite } from "../sites/surugaya";
  * https://gyazo.com/369f88d61f358ea642d91964e5c682fc
  */
 class Surugaya extends DetailContentScript<SurugayaScrapedData> {
-  protected readonly SERVICE = surugayaSite.service;
   protected readonly rootElementMountPoint = {
     target: "body > div.dialog-off-canvas-main-canvas > header > div.top_nav",
   };

--- a/src/contentScript/Toranoana.tsx
+++ b/src/contentScript/Toranoana.tsx
@@ -8,7 +8,6 @@ import { toranoanaSite } from "../sites/toranoana";
  * https://ec.toranoana.jp/tora_r/ec/item/
  */
 class Toranoana extends DetailContentScript<ToranoanaScrapedData> {
-  protected readonly SERVICE = toranoanaSite.service;
   protected readonly rootElementMountPoint = { target: "header" };
 
   protected scrapeData(): ToranoanaScrapedData | null {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist/js",
+    "resolveJsonModule": true,
     "rootDir": "src",
     "sourceMap": true,
     "target": "es6"


### PR DESCRIPTION
## Summary

- remove the unused `SERVICE` requirement from `BaseContentScript`
- remove dead `SERVICE` assignments from all 12 detail content scripts and test subclasses
- enable TypeScript JSON module resolution so the registry test introduced by PR #40 does not break production builds

## Why

PR #40 moved product construction and service metadata into the typed definitions under `src/sites`. The content-script `SERVICE` property is no longer read, so keeping it forces every subclass to implement dead configuration and obscures the metadata that is actually used at runtime.

The site definitions and their `service` fields remain unchanged, so product construction and generated Cosense content keep the same behavior.

Closes #41

## Validation

- `npm run fmt`
- `npm test` — 113 tests passed
- `npm run dep:check`
- `npm run build:chrome`
- `npm run build:firefox`
- `git diff --check`
