### PR TITLE
refactor: add Phase 5 site registry

### DIFF
--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -7,7 +7,7 @@
 > Phase 6（フィクスチャテストの導入）は主要対象の実ページ由来 HTML fixture と Small characterization test を追加済み。
 > Phase 3（Scraper 契約の統一）は完了済み。`publishedAt` の `Date | null` 統一、scraped data 型の集約、scraper logging 集約、Amazon publisher parse 修正、Amazon speculative fallback selector 削減を追加済み。
 > Phase 2（Product 責務分離）は完了。`titleForSearch` と Scrapbox placeholder formatter を pure domain function として `src/domain` に抽出し、`createScrapboxBodyString` を storage 非依存の同期 pure メソッド化、全角→半角変換を `src/domain/halfWidth.ts` に集約、各 product class の default format を `{token}` 化して toTemplateVars 経由の1経路に統一済み。
-> Phase 4（Content Script 共通化）は完了。次の作業対象は Phase 5。
+> Phase 4（Content Script 共通化）と Phase 5（サイトレジストリ化）は完了。次の作業対象は Phase 7b。
 > 今後はフル Clean Architecture ではなく、uni の規模に合わせた **DDD-lite + 最小 port 境界** を採用する。
 
 ## 0. 現在地
@@ -155,7 +155,7 @@ hampu と同じ考え方で、方向性チェックをCIに入れる。
 
 **Phase 7a → Phase 6 → Phase 3 → Phase 2 → Phase 4 → Phase 5 → Phase 7b → Phase 8**
 
-Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 は完了済みとして扱う。次の作業対象は Phase 5。
+Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 / Phase 5 は完了済みとして扱う。次の作業対象は Phase 7b。
 
 ### Phase 1.5 — 検索境界の完全 DTO 化と sendMessage 一本化（完了）
 
@@ -329,7 +329,7 @@ CI強化:
 
 - Phase 7b で entrypoint 規約が変わる可能性があるため、ファイル移動は最小限にする。
 
-### Phase 5 — サイトレジストリ化
+### Phase 5 — サイトレジストリ化（完了）
 
 目的:
 
@@ -348,6 +348,12 @@ Phase 7a の結論に従う:
 - scraper
 - product factory
 - content script entry
+
+成果:
+
+- `src/sites/registry.ts` に全14エントリの service / host / match pattern / product type / scraper / product factory / content script entry を集約。
+- manifest と registry の content script / match pattern が一致することを Small test で固定。
+- ADR-002 に従い、webpack / manifest / declarativeContent の自前生成は行わない。
 
 ### Phase 7b — ビルド基盤の本移行
 

--- a/src/__tests__/small/sites/registry.test.ts
+++ b/src/__tests__/small/sites/registry.test.ts
@@ -1,0 +1,28 @@
+import manifest from "../../../manifest.json";
+import { siteRegistry } from "../../../sites/registry";
+
+describe("site registry", () => {
+  it("covers every manifest content script without match-pattern drift", () => {
+    const registryScripts = Object.values(siteRegistry).map((site) => ({
+      matches: [...site.matches],
+      js: [`js/${site.contentScriptOutput}.js`],
+    }));
+
+    expect(registryScripts).toEqual(manifest.content_scripts);
+  });
+
+  it("keeps required site metadata complete", () => {
+    for (const site of Object.values(siteRegistry)) {
+      expect(site.service).not.toBe("");
+      expect(site.hosts.length).toBeGreaterThan(0);
+      expect(site.matches.length).toBeGreaterThan(0);
+      expect(site.productTypes.length).toBeGreaterThan(0);
+      expect(site.productFactory).not.toBe("");
+      expect(site.contentScriptEntry).toMatch(/^contentScript\/.+\.tsx$/);
+
+      for (const match of site.matches) {
+        expect(site.hosts).toContain(new URL(match.replace("*", "x")).host);
+      }
+    }
+  });
+});

--- a/src/sites/registry.ts
+++ b/src/sites/registry.ts
@@ -1,0 +1,200 @@
+import { AcceptedService } from "../constant";
+import {
+  scrapeAmazonData,
+  scrapeBookWalkerData,
+  scrapeDLsiteBooksData,
+  scrapeDLsiteManiaxData,
+  scrapeFanzaAnimeData,
+  scrapeFanzaBooksData,
+  scrapeFanzaDoujinData,
+  scrapeFanzaVideoData,
+  scrapeFc2ContentMarketData,
+  scrapeMelonbooksData,
+  scrapeSurugayaData,
+  scrapeToranoanaData,
+} from "../scraping";
+
+type ProductType = "asmr" | "book" | "doujinshi" | "film";
+type Scraper = (document: Document) => unknown;
+
+export type SiteDefinition = Readonly<{
+  service: AcceptedService;
+  hosts: readonly string[];
+  matches: readonly string[];
+  productTypes: readonly ProductType[];
+  scraper: Scraper | null;
+  productFactory: string;
+  contentScriptEntry: string;
+  contentScriptOutput: string;
+}>;
+
+/**
+ * Framework-independent source of truth for supported site entrypoints.
+ *
+ * Phase 5 deliberately does not generate webpack or manifest configuration
+ * from this registry. WXT will consume this metadata after Phase 7b.
+ * `productFactory` is a stable name because factories currently live inside
+ * side-effectful content-script entrypoints and must not be imported here.
+ */
+export const siteRegistry = {
+  fanzaBooks: {
+    service: AcceptedService.fanza,
+    hosts: ["book.dmm.co.jp"],
+    matches: ["https://book.dmm.co.jp/*"],
+    productTypes: ["book"],
+    scraper: scrapeFanzaBooksData,
+    productFactory: "FanzaBooks.createProduct",
+    contentScriptEntry: "contentScript/FanzaBooks.tsx",
+    contentScriptOutput: "fanzaBooks",
+  },
+  fanzaDoujin: {
+    service: AcceptedService.fanzaDojin,
+    hosts: ["www.dmm.co.jp"],
+    matches: ["https://www.dmm.co.jp/dc/doujin/-/detail/=/*"],
+    productTypes: ["doujinshi"],
+    scraper: scrapeFanzaDoujinData,
+    productFactory: "FanzaDoujin.createProduct",
+    contentScriptEntry: "contentScript/FanzaDoujin.tsx",
+    contentScriptOutput: "fanzaDoujin",
+  },
+  fanzaVideo: {
+    service: AcceptedService.fanzaVideo,
+    hosts: ["www.dmm.co.jp", "video.dmm.co.jp"],
+    matches: [
+      "https://www.dmm.co.jp/digital/videoa/-/detail/=/*",
+      "https://video.dmm.co.jp/av/content/*",
+    ],
+    productTypes: ["film"],
+    scraper: scrapeFanzaVideoData,
+    productFactory: "FanzaVideo.createProduct",
+    contentScriptEntry: "contentScript/FanzaVideo.tsx",
+    contentScriptOutput: "fanzaVideo",
+  },
+  fanzaAnime: {
+    service: AcceptedService.fanzaAnime,
+    hosts: ["video.dmm.co.jp"],
+    matches: ["https://video.dmm.co.jp/anime/content/*"],
+    productTypes: ["film"],
+    scraper: scrapeFanzaAnimeData,
+    productFactory: "FanzaAnime.createProduct",
+    contentScriptEntry: "contentScript/FanzaAnime.tsx",
+    contentScriptOutput: "fanzaAnime",
+  },
+  dlsiteBooks: {
+    service: AcceptedService.dlsite,
+    hosts: ["www.dlsite.com"],
+    matches: ["https://www.dlsite.com/books/work/=/product_id/*"],
+    productTypes: ["book"],
+    scraper: scrapeDLsiteBooksData,
+    productFactory: "DLsiteBooks.createProduct",
+    contentScriptEntry: "contentScript/DLsiteBooks.tsx",
+    contentScriptOutput: "dlsite",
+  },
+  dlsiteManiax: {
+    service: AcceptedService.dlsiteManiax,
+    hosts: ["www.dlsite.com"],
+    matches: [
+      "https://www.dlsite.com/maniax/work/=/product_id/*",
+      "https://www.dlsite.com/home/work/=/product_id/*",
+      "https://www.dlsite.com/girls/work/=/product_id/*",
+      "https://www.dlsite.com/aix/work/=/product_id/*",
+    ],
+    productTypes: ["doujinshi", "asmr"],
+    scraper: scrapeDLsiteManiaxData,
+    productFactory: "DLsiteManiax.createProduct",
+    contentScriptEntry: "contentScript/DLsiteManiax.tsx",
+    contentScriptOutput: "dlsiteManiax",
+  },
+  toranoana: {
+    service: AcceptedService.toranoana,
+    hosts: ["ec.toranoana.jp", "ecs.toranoana.jp"],
+    matches: [
+      "https://ec.toranoana.jp/tora_r/ec/item/*",
+      "https://ecs.toranoana.jp/tora/ec/item/*",
+    ],
+    productTypes: ["doujinshi"],
+    scraper: scrapeToranoanaData,
+    productFactory: "Toranoana.createProduct",
+    contentScriptEntry: "contentScript/Toranoana.tsx",
+    contentScriptOutput: "toranoana",
+  },
+  melonbooks: {
+    service: AcceptedService.melonbooks,
+    hosts: ["www.melonbooks.co.jp"],
+    matches: ["https://www.melonbooks.co.jp/detail/detail.php*"],
+    productTypes: ["doujinshi"],
+    scraper: scrapeMelonbooksData,
+    productFactory: "Melonbooks.createProduct",
+    contentScriptEntry: "contentScript/Melonbooks.tsx",
+    contentScriptOutput: "melonbooks",
+  },
+  amazon: {
+    service: AcceptedService.amazon,
+    hosts: ["www.amazon.co.jp"],
+    matches: [
+      "https://www.amazon.co.jp/dp/*",
+      "https://www.amazon.co.jp/*/dp/*",
+      "https://www.amazon.co.jp/gp/product/*",
+    ],
+    productTypes: ["book"],
+    scraper: scrapeAmazonData,
+    productFactory: "Amazon.createProduct",
+    contentScriptEntry: "contentScript/Amazon.tsx",
+    contentScriptOutput: "amazon",
+  },
+  bookWalker: {
+    service: AcceptedService.bookWalker,
+    hosts: ["bookwalker.jp"],
+    matches: ["https://bookwalker.jp/*"],
+    productTypes: ["book"],
+    scraper: scrapeBookWalkerData,
+    productFactory: "BookWalker.createProduct",
+    contentScriptEntry: "contentScript/BookWalker.tsx",
+    contentScriptOutput: "bookWalker",
+  },
+  fc2ContentMarket: {
+    service: AcceptedService.fc2ContentMarket,
+    hosts: ["adult.contents.fc2.com"],
+    matches: ["https://adult.contents.fc2.com/article/*"],
+    productTypes: ["film"],
+    scraper: scrapeFc2ContentMarketData,
+    productFactory: "FC2ContentMarket.createProduct",
+    contentScriptEntry: "contentScript/Fc2ContentMarket.tsx",
+    contentScriptOutput: "fc2ContentMarket",
+  },
+  surugaya: {
+    service: AcceptedService.surugaya,
+    hosts: ["www.suruga-ya.jp"],
+    matches: ["https://www.suruga-ya.jp/product/detail/*"],
+    productTypes: ["doujinshi"],
+    scraper: scrapeSurugayaData,
+    productFactory: "Surugaya.createProduct",
+    contentScriptEntry: "contentScript/Surugaya.tsx",
+    contentScriptOutput: "surugaya",
+  },
+  dmmBasket: {
+    service: AcceptedService.dmmDoujinBasket,
+    hosts: ["www.dmm.co.jp"],
+    matches: ["https://www.dmm.co.jp/dc/doujin/-/basket/*"],
+    productTypes: ["doujinshi"],
+    scraper: null,
+    productFactory: "DMMBasketCheckerConfig.createProduct",
+    contentScriptEntry: "contentScript/DMMBasket.tsx",
+    contentScriptOutput: "DMMBasket",
+  },
+  dlsiteCart: {
+    service: AcceptedService.dlsite,
+    hosts: ["www.dlsite.com"],
+    matches: [
+      "https://www.dlsite.com/home/cart*",
+      "https://www.dlsite.com/maniax/cart*",
+      "https://www.dlsite.com/girls/cart*",
+      "https://www.dlsite.com/aix/cart*",
+    ],
+    productTypes: ["doujinshi"],
+    scraper: null,
+    productFactory: "DLsiteCartCheckerConfig.createProduct",
+    contentScriptEntry: "contentScript/DLsiteCart.tsx",
+    contentScriptOutput: "DLsiteCart",
+  },
+} as const satisfies Record<string, SiteDefinition>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "dist/js",
+    "resolveJsonModule": true,
     "rootDir": "src",
     "sourceMap": true,
     "target": "es6"


### PR DESCRIPTION
## Summary

- add a framework-independent registry for all 14 supported content-script entries
- capture each site's service, hosts, match patterns, product types, scraper, product factory identifier, source entry, and webpack output name
- add a Small test that detects drift between the registry and manifest content scripts
- mark Phase 5 complete and Phase 7b as the next refactoring step

## Why

Site metadata was spread across the manifest, webpack configuration, content scripts, and background rules. Phase 5 establishes a typed source of truth without introducing a generator that would be discarded during the planned WXT migration.

## Validation

- `npm test` (111 tests passed)
- `npm run build:chrome`
- `npm run build:firefox`
- `npm run dep:check`
- `git diff --check`

## Notes

`npm run build` still fails because the existing script does not set `TARGET_BROWSER`; both browser-specific production builds pass.
