### PR TITLE
refactor: lighten content script UI runtime

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -87,6 +87,19 @@ module.exports = {
             },
         },
         {
+            name: "content-script-ui-must-use-preact",
+            severity: "error",
+            comment:
+                "Content-script UI uses Preact compat to avoid bundling React in every site entry. The popup may continue to use React.",
+            from: {
+                path: ["^src/contentScript/", "^src/organism/"],
+            },
+            to: {
+                dependencyTypes: ["npm"],
+                path: ["^react$", "^react-dom"],
+            },
+        },
+        {
             name: "products-must-not-import-storage-keys",
             severity: "error",
             comment:

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -1,13 +1,13 @@
 # uni リファクタリング計画（Phase 1 完了後）
 
-> 更新: 2026-07-10 / 最新 `main` (`64f0661`, `Merge pull request #39 from motoso/codex/fix-alert-bar-overflow`) を基準に更新。
+> 更新: 2026-07-13 / 最新 `main` (`50a02a1`, `Merge pull request #44 from motoso/codex/phase7b-wxt`) を基準に更新。
 > Phase 1（Product 丸ごと越境の廃止、検索 query DTO 化、null ガード、background の projectName 再読込、port 経路エラー応答）は完了済み。
 > Phase 1.5（検索境界の完全 DTO 化、`sendMessage` 一本化、port 経路廃止）は完了済み。
 > Phase 7a（ビルド/エントリ基盤の方針決定 ADR）は完了済み。WXT を採用方針とし、Phase 5 では自前 generator を作り込まない。
 > Phase 6（フィクスチャテストの導入）は主要対象の実ページ由来 HTML fixture と Small characterization test を追加済み。
 > Phase 3（Scraper 契約の統一）は完了済み。`publishedAt` の `Date | null` 統一、scraped data 型の集約、scraper logging 集約、Amazon publisher parse 修正、Amazon speculative fallback selector 削減を追加済み。
 > Phase 2（Product 責務分離）は完了。`titleForSearch` と Scrapbox placeholder formatter を pure domain function として `src/domain` に抽出し、`createScrapboxBodyString` を storage 非依存の同期 pure メソッド化、全角→半角変換を `src/domain/halfWidth.ts` に集約、各 product class の default format を `{token}` 化して toTemplateVars 経由の1経路に統一済み。
-> Phase 4（Content Script 共通化）は完了。Phase 5（サイトレジストリ化）は、詳細商品サイトの service / host / match pattern / product type / scraper / product factory / content script entry を framework 非依存の `src/sites` に集約済み。Phase 7b（WXT へのビルド基盤移行）は完了済み。次の作業対象は Phase 8。
+> Phase 4（Content Script 共通化）は完了。Phase 5（サイトレジストリ化）は、詳細商品サイトの service / host / match pattern / product type / scraper / product factory / content script entry を framework 非依存の `src/sites` に集約済み。Phase 7b（WXT へのビルド基盤移行）と Phase 8（バー UI の Preact compat 化）は完了済み。
 > 今後はフル Clean Architecture ではなく、uni の規模に合わせた **DDD-lite + 最小 port 境界** を採用する。
 
 ## 0. 現在地
@@ -376,7 +376,7 @@ Phase 7a の結論に従う:
 - Chrome の `declarativeContent` permission と Firefox の gecko 設定を browser target ごとの manifest 設定として維持。
 - 既存の runtime logic は薄い entrypoint adapter から読み込み、移行時のロジック変更を回避。
 
-### Phase 8 — バー UI ランタイム軽量化
+### Phase 8 — バー UI ランタイム軽量化（完了）
 
 目的:
 
@@ -391,6 +391,14 @@ Phase 7a の結論に従う:
 
 - 1サイトだけ PoC し、bundle size と保守性を比較する。
 - popup は React 維持でよい。対象は content script のバー UI のみ。
+
+PoC 実測（基準 `50a02a1`、BookWalker content script 単体、Chrome MV3 production build、`wc -c` / `gzip -c | wc -c`）:
+
+- React: 218,986 bytes（gzip 69,107 bytes）
+- Preact compat: 47,182 bytes（gzip 17,308 bytes）
+- 削減率: 約 78.5%（gzip 約 75.0%）
+
+上記結果から Preact compat を採用し、popup は React のまま、content script のバー UI とカート UI のみ切り替える。
 
 ## 6. リファクタとは別に切り出す Issue
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "dayjs": "1.11.19",
         "ky": "1.14.2",
+        "preact": "10.29.7",
         "react": "19.2.0",
         "react-dom": "19.2.0"
       },
@@ -9141,6 +9142,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prettier": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
@@ -17932,6 +17951,12 @@
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
       "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "dev": true
+    },
+    "preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "requires": {}
     },
     "prettier": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "dayjs": "1.11.19",
     "ky": "1.14.2",
+    "preact": "10.29.7",
     "react": "19.2.0",
     "react-dom": "19.2.0"
   }

--- a/src/contentScript/BaseContentScript.tsx
+++ b/src/contentScript/BaseContentScript.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { createRoot } from "react-dom/client";
+import * as React from "preact/compat";
+import { createRoot } from "preact/compat/client";
 import { CreatePageBar } from "../organism/CreatePageBar";
 import { AlertBar } from "../organism/AlertBar";
 import Product from "../Product";

--- a/src/contentScript/CartScrapboxChecker.tsx
+++ b/src/contentScript/CartScrapboxChecker.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { createRoot } from "react-dom/client";
+import * as React from "preact/compat";
+import { createRoot } from "preact/compat/client";
 import { StorageKeyProjectName } from "../chromeApi";
 import Product from "../Product";
 import ScrapboxApiClient from "../scrapbox/scrapboxApi";

--- a/src/contentScript/cartScrapboxLinks.tsx
+++ b/src/contentScript/cartScrapboxLinks.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "preact/compat";
 import { ScrapboxPageDto } from "../scrapbox/searchDtos";
 
 export type CartScrapboxLink = {

--- a/src/organism/AlertBar.tsx
+++ b/src/organism/AlertBar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "preact/compat";
 import Product from "../Product";
 import { createScrapboxPageUrl } from "./CreatePageBar";
 

--- a/src/organism/CreatePageBar.tsx
+++ b/src/organism/CreatePageBar.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import * as React from "preact/compat";
 import Product from "../Product";
 import { scrapboxPageUrl } from "../scrapbox/scrapboxPageUrl";
 import { readScrapboxFormats } from "../settings/scrapboxFormatSettings";


### PR DESCRIPTION
## Summary

- replace React with Preact compat in content-script bar and cart UIs
- keep the popup on React
- prevent content-script UI from reintroducing React through dependency-cruiser
- record the Phase 8 decision and bundle-size comparison

## Why

Each content-script entry bundled its own React DOM runtime. A BookWalker production-build comparison reduced the content-script JavaScript from 218,986 bytes to 47,182 bytes (approximately 78.5%) with Preact compat, while retaining the existing component API.

## Impact

- Chrome and Firefox extension behavior is intended to remain unchanged.
- Content-script bundles are approximately 39–48 KB each instead of approximately 209–220 KB.
- The popup continues to use React 19 and remains a separate bundle.

## Validation

- `npm run fmt`
- `npm test` — 113 tests passed
- `npm run dep:check`
- `npx tsc --noEmit`
- `npm run build:chrome`
- `npm run build:firefox`
- `npm run package:all`
- independent Codex subagent review
