### PR TITLE
refactor: separate background search boundaries

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -235,6 +235,23 @@ module.exports = {
                 ],
             },
         },
+        {
+            name: "infrastructure-must-not-depend-on-usecases-or-presentation",
+            severity: "error",
+            comment:
+                "Infrastructure implements ports and must not call usecases or depend on presentation code.",
+            from: {
+                path: "^src/infrastructure/",
+            },
+            to: {
+                path: [
+                    "^src/usecase/",
+                    "^src/contentScript/",
+                    "^src/organism/",
+                    "^src/popup/",
+                ],
+            },
+        },
     ],
     options: {
         doNotFollow: {

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -1,6 +1,6 @@
 # uni リファクタリング計画（Phase 1 完了後）
 
-> 更新: 2026-07-13 / 最新 `main` (`50a02a1`, `Merge pull request #44 from motoso/codex/phase7b-wxt`) を基準に更新。
+> 更新: 2026-07-13 / 最新 `main` (`33ee59b`, `Merge pull request #45 from motoso/codex/phase8-ui-runtime`) を基準に更新。
 > Phase 1（Product 丸ごと越境の廃止、検索 query DTO 化、null ガード、background の projectName 再読込、port 経路エラー応答）は完了済み。
 > Phase 1.5（検索境界の完全 DTO 化、`sendMessage` 一本化、port 経路廃止）は完了済み。
 > Phase 7a（ビルド/エントリ基盤の方針決定 ADR）は完了済み。WXT を採用方針とし、Phase 5 では自前 generator を作り込まない。
@@ -155,7 +155,7 @@ hampu と同じ考え方で、方向性チェックをCIに入れる。
 
 **Phase 7a → Phase 6 → Phase 3 → Phase 2 → Phase 4 → Phase 5 → Phase 7b → Phase 8**
 
-Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 / Phase 5 / Phase 7b は完了済みとして扱う。次の作業対象は Phase 8。
+Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 / Phase 5 / Phase 7b / Phase 8 は完了済みとして扱う。計画済みのアーキテクチャ改善は完了し、以後は「リファクタとは別に切り出す Issue」を個別に扱う。
 
 ### Phase 1.5 — 検索境界の完全 DTO 化と sendMessage 一本化（完了）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "dayjs": "1.11.19",
-        "ky": "1.14.2",
         "preact": "10.29.7",
         "react": "19.2.0",
         "react-dom": "19.2.0"
@@ -7345,6 +7344,7 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.2.tgz",
       "integrity": "sha512-q3RBbsO5A5zrPhB6CaCS8ZUv+NWCXv6JJT4Em0i264G9W0fdPB8YRfnnEi7Dm7X7omAkBIPojzYJ2D1oHTHqug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -16824,7 +16824,8 @@
     "ky": {
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.2.tgz",
-      "integrity": "sha512-q3RBbsO5A5zrPhB6CaCS8ZUv+NWCXv6JJT4Em0i264G9W0fdPB8YRfnnEi7Dm7X7omAkBIPojzYJ2D1oHTHqug=="
+      "integrity": "sha512-q3RBbsO5A5zrPhB6CaCS8ZUv+NWCXv6JJT4Em0i264G9W0fdPB8YRfnnEi7Dm7X7omAkBIPojzYJ2D1oHTHqug==",
+      "dev": true
     },
     "latest-version": {
       "version": "9.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "dependencies": {
     "dayjs": "1.11.19",
-    "ky": "1.14.2",
     "preact": "10.29.7",
     "react": "19.2.0",
     "react-dom": "19.2.0"

--- a/src/__tests__/small/background/event-page-message.test.ts
+++ b/src/__tests__/small/background/event-page-message.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, jest, test } from "@jest/globals";
-import { handleBibliographySearchMessage } from "../../../eventPage";
+import { searchBibliography } from "../../../usecase/searchBibliography";
 import {
   ScrapboxSearchApiResponseDto,
   SearchBibliographyAction,
@@ -48,7 +48,7 @@ test("検索結果がある場合はexistsPageを返す", async () => {
     .fn<SearchFn>()
     .mockResolvedValue(makeRawSearchResponse(1));
 
-  const response = await handleBibliographySearchMessage(
+  const response = await searchBibliography(
     { action: SearchBibliographyAction, query: "検索語" },
     {
       getProjectName: jest
@@ -81,7 +81,7 @@ test("検索結果がある場合はexistsPageを返す", async () => {
 });
 
 test("検索結果がない場合はcreatePageを返す", async () => {
-  const response = await handleBibliographySearchMessage(
+  const response = await searchBibliography(
     { action: SearchBibliographyAction, query: "検索語" },
     {
       getProjectName: jest
@@ -107,7 +107,7 @@ test("queryがない場合はsearchErrorを返して検索しない", async () =
   const getProjectName = jest.fn<() => Promise<string>>();
   const search = jest.fn<SearchFn>();
 
-  const response = await handleBibliographySearchMessage(
+  const response = await searchBibliography(
     { action: SearchBibliographyAction },
     { getProjectName, search },
   );
@@ -124,7 +124,7 @@ test("queryがない場合はsearchErrorを返して検索しない", async () =
 });
 
 test("検索が失敗した場合はsearchErrorを返す", async () => {
-  const response = await handleBibliographySearchMessage(
+  const response = await searchBibliography(
     { action: SearchBibliographyAction, query: "検索語" },
     {
       getProjectName: jest

--- a/src/__tests__/small/background/event-page-message.test.ts
+++ b/src/__tests__/small/background/event-page-message.test.ts
@@ -1,21 +1,17 @@
 import { afterEach, beforeEach, expect, jest, test } from "@jest/globals";
+import type {
+  BibliographySearchGateway,
+  BibliographySearchResult,
+} from "../../../ports/bibliographySearch";
 import { searchBibliography } from "../../../usecase/searchBibliography";
 import {
-  ScrapboxSearchApiResponseDto,
   SearchBibliographyAction,
   SearchBibliographyResponseDto,
 } from "../../../scrapbox/searchDtos";
 
-type SearchFn = (
-  projectName: string,
-  query: string,
-) => Promise<ScrapboxSearchApiResponseDto>;
-
-const makeRawSearchResponse = (count: number): ScrapboxSearchApiResponseDto => {
+const makeSearchResponse = (count: number): BibliographySearchResult => {
   return {
     count,
-    existsExactTitleMatch: count > 0,
-    limit: 30,
     pages:
       count > 0
         ? [
@@ -23,13 +19,9 @@ const makeRawSearchResponse = (count: number): ScrapboxSearchApiResponseDto => {
               image: "https://example.com/image.jpg",
               title: "既存ページ",
               lines: ["line 1", "line 2"],
-              created: 1,
-              updated: 2,
             },
           ]
         : [],
-    projectName: "my-project",
-    query: { words: ["検索語"], excludes: [] },
     searchQuery: "検索語",
   };
 };
@@ -45,8 +37,8 @@ afterEach(() => {
 
 test("検索結果がある場合はexistsPageを返す", async () => {
   const search = jest
-    .fn<SearchFn>()
-    .mockResolvedValue(makeRawSearchResponse(1));
+    .fn<BibliographySearchGateway>()
+    .mockResolvedValue(makeSearchResponse(1));
 
   const response = await searchBibliography(
     { action: SearchBibliographyAction, query: "検索語" },
@@ -87,7 +79,9 @@ test("検索結果がない場合はcreatePageを返す", async () => {
       getProjectName: jest
         .fn<() => Promise<string>>()
         .mockResolvedValue("my-project"),
-      search: jest.fn<SearchFn>().mockResolvedValue(makeRawSearchResponse(0)),
+      search: jest
+        .fn<BibliographySearchGateway>()
+        .mockResolvedValue(makeSearchResponse(0)),
     },
   );
 
@@ -105,7 +99,7 @@ test("検索結果がない場合はcreatePageを返す", async () => {
 
 test("queryがない場合はsearchErrorを返して検索しない", async () => {
   const getProjectName = jest.fn<() => Promise<string>>();
-  const search = jest.fn<SearchFn>();
+  const search = jest.fn<BibliographySearchGateway>();
 
   const response = await searchBibliography(
     { action: SearchBibliographyAction },
@@ -131,7 +125,7 @@ test("検索が失敗した場合はsearchErrorを返す", async () => {
         .fn<() => Promise<string>>()
         .mockResolvedValue("my-project"),
       search: jest
-        .fn<SearchFn>()
+        .fn<BibliographySearchGateway>()
         .mockRejectedValue(new Error("Scrapbox unavailable")),
     },
   );
@@ -141,6 +135,50 @@ test("検索が失敗した場合はsearchErrorを返す", async () => {
     error: {
       message: "Scrapbox unavailable",
       name: "Error",
+    },
+  });
+});
+
+test("project nameの読込が失敗した場合は検索せずerrorを返す", async () => {
+  const search = jest.fn<BibliographySearchGateway>();
+
+  const response = await searchBibliography(
+    { action: SearchBibliographyAction, query: "検索語" },
+    {
+      getProjectName: jest
+        .fn<() => Promise<string>>()
+        .mockRejectedValue(new Error("Storage unavailable")),
+      search,
+    },
+  );
+
+  expect(search).not.toHaveBeenCalled();
+  expect(response).toEqual({
+    status: "error",
+    error: {
+      message: "Storage unavailable",
+      name: "Error",
+    },
+  });
+});
+
+test("Error以外の例外もmessage DTOへ変換する", async () => {
+  const response = await searchBibliography(
+    { action: SearchBibliographyAction, query: "検索語" },
+    {
+      getProjectName: jest
+        .fn<() => Promise<string>>()
+        .mockResolvedValue("my-project"),
+      search: jest
+        .fn<BibliographySearchGateway>()
+        .mockRejectedValue("unknown failure"),
+    },
+  );
+
+  expect(response).toEqual({
+    status: "error",
+    error: {
+      message: "unknown failure",
     },
   });
 });

--- a/src/__tests__/small/infrastructure/scrapbox-search-gateway.test.ts
+++ b/src/__tests__/small/infrastructure/scrapbox-search-gateway.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, expect, jest, test } from "@jest/globals";
+import { searchScrapbox } from "../../../infrastructure/scrapboxSearchGateway";
+
+beforeEach(() => {
+  jest.spyOn(console, "log").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test("標準fetchでCookieを含めてScrapboxを検索する", async () => {
+  const searchResult = {
+    count: 0,
+    searchQuery: "検索語",
+    pages: [],
+  };
+  const fetchMock = jest.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: async () => searchResult,
+  } as Response);
+
+  await expect(searchScrapbox("my-project", "検索語")).resolves.toEqual(
+    searchResult,
+  );
+  expect(fetchMock).toHaveBeenCalledWith(
+    "https://scrapbox.io/api/pages/my-project/search/query?skip=0&sort=updated&limit=30&q=%E6%A4%9C%E7%B4%A2%E8%AA%9E",
+    { credentials: "include" },
+  );
+});
+
+test("Scrapboxが非2xxを返した場合は失敗にする", async () => {
+  jest.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: false,
+    status: 503,
+  } as Response);
+
+  await expect(searchScrapbox("my-project", "検索語")).rejects.toThrow(
+    "Scrapbox search failed: 503",
+  );
+});

--- a/src/eventPage.ts
+++ b/src/eventPage.ts
@@ -1,60 +1,23 @@
 // Listen to messages sent from other parts of the extension.
-import { StorageKeyProjectName } from "./chromeApi";
-import ky from "ky";
 import browser from "webextension-polyfill";
-import { SCRAPBOX_BASE_URL } from "./scrapbox/constants";
-import { scrapboxPageUrl } from "./scrapbox/scrapboxPageUrl";
+import { readProjectName } from "./infrastructure/projectNameReader";
+import { searchScrapbox } from "./infrastructure/scrapboxSearchGateway";
+import type { BibliographySearchDependencies } from "./ports/bibliographySearch";
 import {
-  MessageErrorDto,
-  ScrapboxSearchApiResponseDto,
   SearchBibliographyAction,
   SearchBibliographyRequestDto,
   SearchBibliographyResponseDto,
-  SearchResultDto,
 } from "./scrapbox/searchDtos";
-
-const getProjectName = async (): Promise<string> => {
-  const items = await browser.storage.sync.get([StorageKeyProjectName]);
-  return (items[StorageKeyProjectName] as string) ?? "";
-};
-
-type SearchDependencies = {
-  getProjectName: () => Promise<string>;
-  search: (
-    projectName: string,
-    query: string,
-  ) => Promise<ScrapboxSearchApiResponseDto>;
-};
+import { searchBibliography } from "./usecase/searchBibliography";
 
 export async function handleBibliographySearchMessage(
   request: Partial<SearchBibliographyRequestDto>,
-  dependencies: SearchDependencies = {
-    getProjectName,
-    search: performActualScrapboxSearch,
+  dependencies: BibliographySearchDependencies = {
+    getProjectName: readProjectName,
+    search: searchScrapbox,
   },
 ): Promise<SearchBibliographyResponseDto> {
-  try {
-    if (!request.query) {
-      throw new Error("Missing Scrapbox search query");
-    }
-
-    const currentProjectName = await dependencies.getProjectName();
-    const rawRes = await dependencies.search(currentProjectName, request.query);
-    const searchResult = toSearchResultDto(rawRes, currentProjectName);
-
-    console.log("[eventPage] Search successful:", searchResult);
-    return {
-      status: "ok",
-      projectName: currentProjectName,
-      searchResult,
-    };
-  } catch (error) {
-    console.error("[eventPage] Error during search:", error);
-    return {
-      status: "error",
-      error: toMessageError(error),
-    };
-  }
+  return searchBibliography(request, dependencies);
 }
 
 export function registerBackgroundListeners(): void {
@@ -112,22 +75,6 @@ export function registerBackgroundListeners(): void {
   });
 }
 
-// Function to perform the actual Scrapbox search using ky
-async function performActualScrapboxSearch(
-  projectName: string,
-  query: string,
-): Promise<ScrapboxSearchApiResponseDto> {
-  const params = new URLSearchParams({
-    skip: "0",
-    sort: "updated",
-    limit: "30", // Default limit
-    q: query,
-  });
-  const searchUrl = `${SCRAPBOX_BASE_URL}/api/pages/${projectName}/search/query?${params}`;
-  console.log("[eventPage] Performing direct search on Scrapbox:", searchUrl);
-  return ky.get(searchUrl, { credentials: "include" }).json();
-}
-
 function isSearchBibliographyRequest(
   request: unknown,
 ): request is SearchBibliographyRequestDto {
@@ -136,28 +83,4 @@ function isSearchBibliographyRequest(
     request !== null &&
     (request as { action?: unknown }).action === SearchBibliographyAction
   );
-}
-
-function toSearchResultDto(
-  rawRes: ScrapboxSearchApiResponseDto,
-  projectName: string,
-): SearchResultDto {
-  return {
-    count: rawRes.count,
-    projectName,
-    searchQuery: rawRes.searchQuery,
-    pages: rawRes.pages.map((pageData) => ({
-      title: pageData.title,
-      imageUrl: pageData.image,
-      description: pageData.lines.join("\n"),
-      pageUrl: scrapboxPageUrl(projectName, pageData.title),
-    })),
-  };
-}
-
-function toMessageError(error: unknown): MessageErrorDto {
-  if (error instanceof Error) {
-    return { message: error.message, name: error.name };
-  }
-  return { message: String(error) };
 }

--- a/src/infrastructure/projectNameReader.ts
+++ b/src/infrastructure/projectNameReader.ts
@@ -1,0 +1,8 @@
+import browser from "webextension-polyfill";
+import { StorageKeyProjectName } from "../chromeApi";
+import type { ProjectNameReader } from "../ports/bibliographySearch";
+
+export const readProjectName: ProjectNameReader = async () => {
+  const items = await browser.storage.sync.get([StorageKeyProjectName]);
+  return (items[StorageKeyProjectName] as string) ?? "";
+};

--- a/src/infrastructure/scrapboxSearchGateway.ts
+++ b/src/infrastructure/scrapboxSearchGateway.ts
@@ -1,0 +1,18 @@
+import ky from "ky";
+import type { BibliographySearchGateway } from "../ports/bibliographySearch";
+import { SCRAPBOX_BASE_URL } from "../scrapbox/constants";
+
+export const searchScrapbox: BibliographySearchGateway = async (
+  projectName,
+  query,
+) => {
+  const params = new URLSearchParams({
+    skip: "0",
+    sort: "updated",
+    limit: "30",
+    q: query,
+  });
+  const searchUrl = `${SCRAPBOX_BASE_URL}/api/pages/${projectName}/search/query?${params}`;
+  console.log("[eventPage] Performing direct search on Scrapbox:", searchUrl);
+  return ky.get(searchUrl, { credentials: "include" }).json();
+};

--- a/src/infrastructure/scrapboxSearchGateway.ts
+++ b/src/infrastructure/scrapboxSearchGateway.ts
@@ -1,4 +1,3 @@
-import ky from "ky";
 import type { BibliographySearchGateway } from "../ports/bibliographySearch";
 import { SCRAPBOX_BASE_URL } from "../scrapbox/constants";
 
@@ -14,5 +13,9 @@ export const searchScrapbox: BibliographySearchGateway = async (
   });
   const searchUrl = `${SCRAPBOX_BASE_URL}/api/pages/${projectName}/search/query?${params}`;
   console.log("[eventPage] Performing direct search on Scrapbox:", searchUrl);
-  return ky.get(searchUrl, { credentials: "include" }).json();
+  const response = await fetch(searchUrl, { credentials: "include" });
+  if (!response.ok) {
+    throw new Error(`Scrapbox search failed: ${response.status}`);
+  }
+  return response.json();
 };

--- a/src/ports/bibliographySearch.ts
+++ b/src/ports/bibliographySearch.ts
@@ -1,0 +1,21 @@
+export type ProjectNameReader = () => Promise<string>;
+
+export type BibliographySearchResult = {
+  count: number;
+  searchQuery: string;
+  pages: Array<{
+    image: string;
+    title: string;
+    lines: string[];
+  }>;
+};
+
+export type BibliographySearchGateway = (
+  projectName: string,
+  query: string,
+) => Promise<BibliographySearchResult>;
+
+export type BibliographySearchDependencies = {
+  getProjectName: ProjectNameReader;
+  search: BibliographySearchGateway;
+};

--- a/src/usecase/searchBibliography.ts
+++ b/src/usecase/searchBibliography.ts
@@ -1,0 +1,60 @@
+import type {
+  BibliographySearchDependencies,
+  BibliographySearchResult,
+} from "../ports/bibliographySearch";
+import { scrapboxPageUrl } from "../scrapbox/scrapboxPageUrl";
+import {
+  MessageErrorDto,
+  SearchBibliographyRequestDto,
+  SearchBibliographyResponseDto,
+  SearchResultDto,
+} from "../scrapbox/searchDtos";
+
+export async function searchBibliography(
+  request: Partial<SearchBibliographyRequestDto>,
+  dependencies: BibliographySearchDependencies,
+): Promise<SearchBibliographyResponseDto> {
+  try {
+    if (!request.query) {
+      throw new Error("Missing Scrapbox search query");
+    }
+
+    const projectName = await dependencies.getProjectName();
+    const response = await dependencies.search(projectName, request.query);
+
+    return {
+      status: "ok",
+      projectName,
+      searchResult: toSearchResultDto(response, projectName),
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      error: toMessageError(error),
+    };
+  }
+}
+
+function toSearchResultDto(
+  response: BibliographySearchResult,
+  projectName: string,
+): SearchResultDto {
+  return {
+    count: response.count,
+    projectName,
+    searchQuery: response.searchQuery,
+    pages: response.pages.map((page) => ({
+      title: page.title,
+      imageUrl: page.image,
+      description: page.lines.join("\n"),
+      pageUrl: scrapboxPageUrl(projectName, page.title),
+    })),
+  };
+}
+
+function toMessageError(error: unknown): MessageErrorDto {
+  if (error instanceof Error) {
+    return { message: error.message, name: error.name };
+  }
+  return { message: String(error) };
+}


### PR DESCRIPTION
## Summary

- extract the browser-independent bibliography search flow from `eventPage.ts`
- define minimal project-name and search gateway ports
- move browser storage and Scrapbox HTTP implementations into infrastructure adapters
- use the standard `fetch` API and remove the direct `ky` dependency
- enforce the new dependency direction with dependency-cruiser
- update the refactoring plan to record that its original phases ended with Phase 8

## Why

`eventPage.ts` previously combined runtime listener registration, browser storage access, HTTP access, request validation, error mapping, and response DTO construction. Separating those responsibilities keeps the background entrypoint thin and gives the search use case an explicit, minimal I/O contract. The existing four search-contract tests now target the use case directly; this PR additionally covers project-name read failures, non-`Error` failures, and the standard `fetch` adapter.

This is a follow-up refactor after the original plan completed at Phase 8. It does not introduce or claim a new Phase 9.

## Impact

- no intended user-visible behavior change
- existing search success, empty-result, validation-error, and gateway-error response contracts are preserved
- the search use case can be tested with port substitutes
- the Chrome background bundle is reduced from about 26.67 kB to 13.01 kB

## Validation

- `npm run fmt`
- `npm test` (17 suites, 117 tests)
- `npm run dep:check`
- `npm run build`
- `git diff --check`

## Consultation note

An external Claude Code consultation was requested, but the execution environment blocked sending private workspace data to the external service even after explicit user approval. No external review result is represented in this PR.
