### PR TITLE
refactor: finish UI and dependency cleanup

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -87,19 +87,6 @@ module.exports = {
             },
         },
         {
-            name: "content-script-ui-must-use-preact",
-            severity: "error",
-            comment:
-                "Content-script UI uses Preact compat to avoid bundling React in every site entry. The popup may continue to use React.",
-            from: {
-                path: ["^src/contentScript/", "^src/organism/"],
-            },
-            to: {
-                dependencyTypes: ["npm"],
-                path: ["^react$", "^react-dom"],
-            },
-        },
-        {
             name: "products-must-not-import-storage-keys",
             severity: "error",
             comment:

--- a/docs/refactoring-plan.md
+++ b/docs/refactoring-plan.md
@@ -1,13 +1,14 @@
-# uni リファクタリング計画（Phase 1 完了後）
+# uni リファクタリング計画（完了・アーカイブ）
 
-> 更新: 2026-07-13 / 最新 `main` (`33ee59b`, `Merge pull request #45 from motoso/codex/phase8-ui-runtime`) を基準に更新。
+> **状態: 完了・アーカイブ。** 今後の改善はこの計画を延長せず、個別の Issue として扱う。
+> 更新: 2026-07-13 / 最新 `main` (`0b8fd60`, `Merge pull request #46 from motoso/codex/phase9-search-ports`) を基準に更新。
 > Phase 1（Product 丸ごと越境の廃止、検索 query DTO 化、null ガード、background の projectName 再読込、port 経路エラー応答）は完了済み。
 > Phase 1.5（検索境界の完全 DTO 化、`sendMessage` 一本化、port 経路廃止）は完了済み。
 > Phase 7a（ビルド/エントリ基盤の方針決定 ADR）は完了済み。WXT を採用方針とし、Phase 5 では自前 generator を作り込まない。
 > Phase 6（フィクスチャテストの導入）は主要対象の実ページ由来 HTML fixture と Small characterization test を追加済み。
 > Phase 3（Scraper 契約の統一）は完了済み。`publishedAt` の `Date | null` 統一、scraped data 型の集約、scraper logging 集約、Amazon publisher parse 修正、Amazon speculative fallback selector 削減を追加済み。
 > Phase 2（Product 責務分離）は完了。`titleForSearch` と Scrapbox placeholder formatter を pure domain function として `src/domain` に抽出し、`createScrapboxBodyString` を storage 非依存の同期 pure メソッド化、全角→半角変換を `src/domain/halfWidth.ts` に集約、各 product class の default format を `{token}` 化して toTemplateVars 経由の1経路に統一済み。
-> Phase 4（Content Script 共通化）は完了。Phase 5（サイトレジストリ化）は、詳細商品サイトの service / host / match pattern / product type / scraper / product factory / content script entry を framework 非依存の `src/sites` に集約済み。Phase 7b（WXT へのビルド基盤移行）と Phase 8（バー UI の Preact compat 化）は完了済み。
+> Phase 4（Content Script 共通化）は完了。Phase 5（サイトレジストリ化）は、詳細商品サイトの service / host / match pattern / product type / scraper / product factory / content script entry を framework 非依存の `src/sites` に集約済み。Phase 7b（WXT へのビルド基盤移行）、Phase 8（UI の Preact compat 化）、Phase 9（background 検索処理の port / usecase 分離）は完了済み。
 > 今後はフル Clean Architecture ではなく、uni の規模に合わせた **DDD-lite + 最小 port 境界** を採用する。
 
 ## 0. 現在地
@@ -135,7 +136,7 @@ hampu と同じ考え方で、方向性チェックをCIに入れる。
 - unresolved dependency 禁止。
 - `eventPage.ts` は `Product`/UI/contentScript/scraper を import しない。
 - `src/scraping` は `Product`/UI/extension API/Scrapbox を import しない。
-- 将来の `src/domain` は browser/UI/network/storage/transport に依存しない。`react`, `react-dom`, `ky`, `webextension-polyfill`, `dayjs` などの runtime npm package も直接 import しない。
+- 将来の `src/domain` は browser/UI/network/storage/transport に依存しない。`react`, `react-dom`, `preact`, `ky`, `webextension-polyfill`, `dayjs` などの runtime npm package も直接 import しない。
 - 将来の `src/usecase` は presentation / concrete infrastructure に依存しない。UI / extension runtime / HTTP client の npm package も直接 import しない。
 - 将来の `src/ports` は concrete implementation に依存しない。UI / extension runtime / HTTP client の npm package も直接 import しない。
 
@@ -155,7 +156,7 @@ hampu と同じ考え方で、方向性チェックをCIに入れる。
 
 **Phase 7a → Phase 6 → Phase 3 → Phase 2 → Phase 4 → Phase 5 → Phase 7b → Phase 8**
 
-Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 / Phase 5 / Phase 7b / Phase 8 は完了済みとして扱う。計画済みのアーキテクチャ改善は完了し、以後は「リファクタとは別に切り出す Issue」を個別に扱う。
+Phase 1 / Phase 1.5 / Phase 7a / Phase 6 / Phase 3 / Phase 2 / Phase 4 / Phase 5 / Phase 7b / Phase 8 / Phase 9 は完了済みとして扱う。計画済みのアーキテクチャ改善は完了し、以後は「リファクタとは別に切り出す Issue」を個別に扱う。
 
 ### Phase 1.5 — 検索境界の完全 DTO 化と sendMessage 一本化（完了）
 
@@ -376,7 +377,7 @@ Phase 7a の結論に従う:
 - Chrome の `declarativeContent` permission と Firefox の gecko 設定を browser target ごとの manifest 設定として維持。
 - 既存の runtime logic は薄い entrypoint adapter から読み込み、移行時のロジック変更を回避。
 
-### Phase 8 — バー UI ランタイム軽量化（完了）
+### Phase 8 — UI ランタイム軽量化（完了）
 
 目的:
 
@@ -398,10 +399,16 @@ PoC 実測（基準 `50a02a1`、BookWalker content script 単体、Chrome MV3 pr
 - Preact compat: 47,182 bytes（gzip 17,308 bytes）
 - 削減率: 約 78.5%（gzip 約 75.0%）
 
-上記結果から Preact compat を採用し、popup は React のまま、content script のバー UI とカート UI のみ切り替える。
+上記結果から Preact compat を採用し、content script のバー UI、カート UI、popup を切り替えた。
+
+### Phase 9 — background 検索境界の分離（完了）
+
+- background の検索処理を port / usecase / infrastructure に分離。
+- Scrapbox 検索を標準 `fetch` に移行。
+- dependency-cruiser で検索境界の依存方向を固定。
+- background 検索境界の Small test を追加。
 
 ## 6. リファクタとは別に切り出す Issue
 
 - `titleForSearch` の4語丸めによる「もう買ってるかも」false positive。
-- `SearchResult.existsExactTitleMatch` を実際に使うかどうか。
 - `count >= 1` 判定を厳密化する仕様判断。

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "dayjs": "1.11.19",
-        "preact": "10.29.7",
-        "react": "19.2.0",
-        "react-dom": "19.2.0"
+        "preact": "10.29.7"
       },
       "devDependencies": {
         "@playwright/test": "^1.49.2",
@@ -21,15 +19,12 @@
         "@types/chrome": "0.1.32",
         "@types/jest": "30.0.0",
         "@types/jsdom": "^27.0.0",
-        "@types/react": "19.2.2",
-        "@types/react-dom": "19.2.2",
         "@types/webextension-polyfill": "^0.12.3",
         "dependency-cruiser": "^17.4.3",
         "jest": "30.2.0",
         "jest-webextension-mock": "^4.0.0",
         "jsdom": "^27.0.0",
         "linkedom": "^0.18.12",
-        "node-fetch": "^3.3.2",
         "postcss": "8.5.6",
         "prettier": "3.6.2",
         "sass": "1.93.3",
@@ -3192,26 +3187,6 @@
         "undici-types": "~8.3.0"
       }
     },
-    "node_modules/@types/react": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
-      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-dom": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
-      "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "^19.2.0"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -4828,22 +4803,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/csstype": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
-      "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==",
-      "dev": true
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
@@ -5456,30 +5415,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/filesize": {
       "version": "11.0.22",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.22.tgz",
@@ -5605,19 +5540,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -8516,46 +8438,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
@@ -9407,27 +9289,6 @@
         "destr": "^2.0.5"
       }
     },
-    "node_modules/react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
-      "license": "MIT",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -9748,12 +9609,6 @@
       "engines": {
         "node": ">=v12.22.7"
       }
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
     },
     "node_modules/scule": {
       "version": "1.3.0",
@@ -11540,16 +11395,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webextension-polyfill": {
@@ -14040,22 +13885,6 @@
         "undici-types": "~8.3.0"
       }
     },
-    "@types/react": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
-      "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
-      "requires": {
-        "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-dom": {
-      "version": "19.2.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.2.tgz",
-      "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
-      "dev": true,
-      "requires": {}
-    },
     "@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -15106,18 +14935,6 @@
         "css-tree": "^3.1.0"
       }
     },
-    "csstype": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.2.tgz",
-      "integrity": "sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==",
-      "dev": true
-    },
-    "data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "dev": true
-    },
     "data-urls": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
@@ -15526,16 +15343,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "dev": true,
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "filesize": {
       "version": "11.0.22",
       "resolved": "https://registry.npmjs.org/filesize/-/filesize-11.0.22.tgz",
@@ -15623,15 +15430,6 @@
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-6.0.3.tgz",
       "integrity": "sha512-8e1++BCiTzUno9v5IZ2J6bv4RU+3UKDmqWUQD0MIMVCd9AdhWkO1gw57oo1mNEX1dMq2EGI+FbWz4B92pscSQg==",
       "dev": true
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dev": true,
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
     },
     "fs-extra": {
       "version": "11.3.6",
@@ -17543,23 +17341,6 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
       "dev": true
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "dev": true
-    },
-    "node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "dev": true,
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
-    },
     "node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
@@ -18115,19 +17896,6 @@
         "destr": "^2.0.5"
       }
     },
-    "react": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
-      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ=="
-    },
-    "react-dom": {
-      "version": "19.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
-      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
-      "requires": {
-        "scheduler": "^0.27.0"
-      }
-    },
     "react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -18343,11 +18111,6 @@
       "requires": {
         "xmlchars": "^2.2.0"
       }
-    },
-    "scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "scule": {
       "version": "1.3.0",
@@ -19368,12 +19131,6 @@
           "dev": true
         }
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "dev": true
     },
     "webextension-polyfill": {
       "version": "0.12.0",

--- a/package.json
+++ b/package.json
@@ -39,15 +39,12 @@
     "@types/chrome": "0.1.32",
     "@types/jest": "30.0.0",
     "@types/jsdom": "^27.0.0",
-    "@types/react": "19.2.2",
-    "@types/react-dom": "19.2.2",
     "@types/webextension-polyfill": "^0.12.3",
     "dependency-cruiser": "^17.4.3",
     "jest": "30.2.0",
     "jest-webextension-mock": "^4.0.0",
     "jsdom": "^27.0.0",
     "linkedom": "^0.18.12",
-    "node-fetch": "^3.3.2",
     "postcss": "8.5.6",
     "prettier": "3.6.2",
     "sass": "1.93.3",
@@ -59,8 +56,6 @@
   },
   "dependencies": {
     "dayjs": "1.11.19",
-    "preact": "10.29.7",
-    "react": "19.2.0",
-    "react-dom": "19.2.0"
+    "preact": "10.29.7"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -58,16 +58,6 @@
       ]
     },
     {
-      "description": "Group React packages",
-      "groupName": "React",
-      "matchPackageNames": [
-        "react",
-        "react-dom",
-        "@types/react",
-        "@types/react-dom"
-      ]
-    },
-    {
       "description": "Group Tailwind CSS packages",
       "groupName": "Tailwind CSS",
       "matchPackageNames": [

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useState } from "react";
+import * as React from "preact/compat";
+import { useCallback, useEffect, useState } from "preact/hooks";
 import "./Popup.scss";
 import "../css/tailwind.scss";
 import { StorageKeyProjectName, StorageKeyScrapboxFormats } from "../chromeApi";
@@ -180,7 +181,7 @@ export default function Popup() {
             id="tabs"
             name="tabs"
             className="block w-full rounded-md border-gray-300 focus:border-indigo-500 focus:ring-indigo-500"
-            onChange={(e) => setActiveTab(e.target.value as ProductType)}
+            onChange={(e) => setActiveTab(e.currentTarget.value as ProductType)}
             value={activeTab}
           >
             <option value="book">書籍</option>

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import { createRoot } from "react-dom/client";
+import * as React from "preact/compat";
+import { createRoot } from "preact/compat/client";
 import Popup from "./Popup";
 
 chrome.tabs.query({ active: true, currentWindow: true }, (tab) => {

--- a/src/scrapbox/searchDtos.ts
+++ b/src/scrapbox/searchDtos.ts
@@ -5,24 +5,6 @@ export type MessageErrorDto = {
   name?: string;
 };
 
-export type ScrapboxSearchApiPageDto = {
-  image: string;
-  title: string;
-  lines: string[];
-  created: number;
-  updated: number;
-};
-
-export type ScrapboxSearchApiResponseDto = {
-  count: number;
-  existsExactTitleMatch: boolean;
-  limit: number;
-  pages: ScrapboxSearchApiPageDto[];
-  projectName: string;
-  query: { words: string[]; excludes: string[] };
-  searchQuery: string;
-};
-
 export type ScrapboxPageDto = {
   title: string;
   imageUrl: string;


### PR DESCRIPTION
## Summary

- migrate the extension popup from React to Preact compat
- remove React, React DOM, their type packages, and the unused `node-fetch` dependency
- remove unused raw Scrapbox search DTOs and stale Renovate/dependency rules
- archive the completed refactoring plan and record Phase 9

## Why

The content-script UI already used Preact, while the popup kept React as the final runtime consumer. Moving the popup allows the React runtime and related maintenance configuration to be removed. Phase 9 also made the old raw Scrapbox API DTO definitions unused.

## Impact

The popup keeps the same UI and storage behavior through `preact/compat`. Production dependencies and the lockfile are smaller, and the refactoring plan is now explicitly complete and archived.

## Validation

- `npm run fmt`
- `npm test` (117 tests)
- `npm run dep:check`
- `npx tsc --noEmit`
- `npm run build`
- `npm run build:firefox`
