### PR TITLE
chore: release 2.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "uni",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "uni",
-      "version": "2.1.4",
+      "version": "2.1.5",
       "hasInstallScript": true,
       "dependencies": {
         "dayjs": "1.11.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uni",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "My bibliographies all are in Cosense - Cross-browser extension (Chrome & Firefox compatible)",
   "scripts": {
     "build": "wxt build --browser chrome",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-  testDir: './src',
-  testMatch: '**/__tests__/large/**/*.test.ts',
+  testDir: "./src",
+  testMatch: "**/__tests__/large/**/*.test.ts",
   timeout: process.env.CI ? 180000 : 90000, // CI環境では3分（VPN遅延考慮）、ローカルは1.5分
 
   fullyParallel: !process.env.CI, // CI環境では安定性優先、ローカルは並列
@@ -10,41 +10,44 @@ export default defineConfig({
   retries: process.env.CI ? 3 : 0, // CI環境では3回リトライでfalse positive削減
   workers: process.env.CI ? 1 : undefined, // CI環境では安定性優先で1ワーカー
 
-  reporter: process.env.CI ? 'github' : 'html',
+  reporter: process.env.CI ? "github" : "html",
 
   use: {
     headless: !!process.env.CI, // CI環境ではヘッドレスモード強制
-    trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
     // CI環境ではVPN遅延を考慮してより長いタイムアウトを設定
     navigationTimeout: process.env.CI ? 90000 : 30000, // VPN環境では1.5分
     actionTimeout: process.env.CI ? 30000 : 10000, // VPN環境では30秒
     // CI環境でのUser-Agent設定（サイトのブロック回避）
-    userAgent: process.env.CI ? 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36' : undefined,
+    userAgent: process.env.CI
+      ? "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+      : undefined,
     // 日本語サイト全般のボット検出回避設定（全テストに適用）
     // 対象: BookWalker, DLsite, FANZA, Melonbooks, Toranoana, Surugaya等の日本語ECサイト
     // 日本在住ユーザーを模倣することで、地理的制限やボット検出を回避
-    locale: 'ja-JP',
-    timezoneId: 'Asia/Tokyo',
+    locale: "ja-JP",
+    timezoneId: "Asia/Tokyo",
     extraHTTPHeaders: {
-      'Accept-Language': 'ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7',
-      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8',
+      "Accept-Language": "ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7",
+      Accept:
+        "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
     },
   },
 
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
     {
-      name: 'firefox',
+      name: "firefox",
       use: {
-        ...devices['Desktop Firefox'],
+        ...devices["Desktop Firefox"],
         // Firefox用の最適化されたタイムアウト設定
         navigationTimeout: 45000, // ナビゲーション用（デフォルト30秒より長め）
-        actionTimeout: 15000,     // アクション用（デフォルト10秒より長め）
+        actionTimeout: 15000, // アクション用（デフォルト10秒より長め）
       },
     },
   ],

--- a/src/__tests__/large/monitoring/access-check.test.ts
+++ b/src/__tests__/large/monitoring/access-check.test.ts
@@ -1,26 +1,26 @@
-import { test, expect } from '@playwright/test';
-import { staticSites, spaSites } from './shared';
+import { test, expect } from "@playwright/test";
+import { staticSites, spaSites } from "./shared";
 
 // CI環境でのアクセス状況確認用テスト
 const allSites = [...staticSites, ...spaSites];
 
 allSites.forEach(({ service, url, requiresJapanIP }) => {
-  const tag = requiresJapanIP ? '@japan' : '@global';
+  const tag = requiresJapanIP ? "@japan" : "@global";
   test.describe(`${tag} Site Access Check`, () => {
     test(`Access check: ${service}`, async ({ page }) => {
       const isCI = !!process.env.CI;
 
       if (isCI && !process.env.SKIP_IP_INFO) {
         // CI環境の情報を取得
-        console.log('🌍 CI Environment Info:');
+        console.log("🌍 CI Environment Info:");
 
         // IP情報取得
         try {
-          await page.goto('https://ipinfo.io/json');
-          const ipInfo = await page.textContent('pre');
+          await page.goto("https://ipinfo.io/json");
+          const ipInfo = await page.textContent("pre");
           console.log(`IP Info: ${ipInfo}`);
         } catch (error) {
-          console.log('Failed to get IP info');
+          console.log("Failed to get IP info");
         }
       }
 
@@ -29,20 +29,26 @@ allSites.forEach(({ service, url, requiresJapanIP }) => {
       try {
         // ページアクセスを試行
         const response = await page.goto(url, {
-          waitUntil: 'commit',
-          timeout: 30000
+          waitUntil: "commit",
+          timeout: 30000,
         });
 
         const status = response?.status() || 0;
-        const statusText = response?.statusText() || 'Unknown';
-        const headers = await response?.headers() || {};
+        const statusText = response?.statusText() || "Unknown";
+        const headers = (await response?.headers()) || {};
 
         console.log(`✅ Status: ${status} ${statusText}`);
         console.log(`📍 Final URL: ${page.url()}`);
 
         // ヘッダー情報
-        const interestingHeaders = ['server', 'cf-ray', 'x-forwarded-for', 'location', 'set-cookie'];
-        interestingHeaders.forEach(header => {
+        const interestingHeaders = [
+          "server",
+          "cf-ray",
+          "x-forwarded-for",
+          "location",
+          "set-cookie",
+        ];
+        interestingHeaders.forEach((header) => {
           if (headers[header]) {
             console.log(`📋 ${header}: ${headers[header]}`);
           }
@@ -53,41 +59,55 @@ allSites.forEach(({ service, url, requiresJapanIP }) => {
         console.log(`📄 Page Title: ${title}`);
 
         // ブロック・エラーページの検出
-        const content = await page.textContent('body');
+        const content = await page.textContent("body");
         if (content) {
           const blockIndicators = [
-            'access denied', 'forbidden', 'blocked', 'unavailable',
-            'geo-blocked', 'region', 'country', 'location',
-            'アクセスが拒否', 'アクセスできません', '利用できません',
-            '地域制限', '国外', '海外'
+            "access denied",
+            "forbidden",
+            "blocked",
+            "unavailable",
+            "geo-blocked",
+            "region",
+            "country",
+            "location",
+            "アクセスが拒否",
+            "アクセスできません",
+            "利用できません",
+            "地域制限",
+            "国外",
+            "海外",
           ];
 
-          const foundIndicators = blockIndicators.filter(indicator =>
-            content.toLowerCase().includes(indicator.toLowerCase())
+          const foundIndicators = blockIndicators.filter((indicator) =>
+            content.toLowerCase().includes(indicator.toLowerCase()),
           );
 
           if (foundIndicators.length > 0) {
-            console.log(`🚫 Potential blocking indicators found: ${foundIndicators.join(', ')}`);
+            console.log(
+              `🚫 Potential blocking indicators found: ${foundIndicators.join(", ")}`,
+            );
           }
         }
 
         // 年齢認証ページかどうかチェック
-        if (title.includes('年齢認証') || page.url().includes('age_check')) {
-          console.log('🔞 Age verification page detected');
+        if (title.includes("年齢認証") || page.url().includes("age_check")) {
+          console.log("🔞 Age verification page detected");
         }
 
         // ログインページかどうかチェック
-        if (title.includes('ログイン') || page.url().includes('login')) {
-          console.log('🔑 Login page detected');
+        if (title.includes("ログイン") || page.url().includes("login")) {
+          console.log("🔑 Login page detected");
         }
 
         // ステータスコードに基づく判定
         if (status >= 200 && status < 300) {
-          console.log('✅ Access successful');
+          console.log("✅ Access successful");
         } else if (status === 403) {
-          console.log('🚫 Access forbidden (403)');
+          console.log("🚫 Access forbidden (403)");
         } else if (status === 451) {
-          console.log('🌍 Unavailable for legal reasons (451) - likely geo-blocked');
+          console.log(
+            "🌍 Unavailable for legal reasons (451) - likely geo-blocked",
+          );
         } else if (status >= 400) {
           console.log(`❌ Client error (${status})`);
         } else if (status >= 500) {
@@ -96,9 +116,10 @@ allSites.forEach(({ service, url, requiresJapanIP }) => {
 
         // テストとしては常に成功（情報収集目的）
         expect(status).toBeGreaterThan(0);
-
       } catch (error) {
-        console.log(`❌ Access failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        console.log(
+          `❌ Access failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
 
         // エラーの場合もテストを続行（情報収集目的）
         expect(error).toBeDefined();

--- a/src/__tests__/large/monitoring/amazon-debug.test.ts
+++ b/src/__tests__/large/monitoring/amazon-debug.test.ts
@@ -1,24 +1,26 @@
-import { test, expect } from '@playwright/test';
-import { navigateWithStealth } from './shared';
+import { test, expect } from "@playwright/test";
+import { navigateWithStealth } from "./shared";
 
 // CI環境でのAmazon日本語サイトのDOM構造デバッグ用テスト
 // 通常は無効化しているが、専用デバッグワークフローでは実行される
-const isDebugWorkflow = process.env.GITHUB_WORKFLOW === 'Debug CI Environment';
+const isDebugWorkflow = process.env.GITHUB_WORKFLOW === "Debug CI Environment";
 const describeMethod = isDebugWorkflow ? test.describe : test.describe.skip;
 
-describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
+describeMethod("Amazon (Japanese) DOM Structure Debug", () => {
   const amazonSite = {
-    name: 'Amazon (Japanese)',
-    url: 'https://www.amazon.co.jp/%E3%81%8A%E5%85%84%E3%81%A1%E3%82%83%E3%82%93%E3%81%AF%E3%81%8A%E3%81%97%E3%81%BE%E3%81%84-6-ID%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%82%B9-%E3%81%AD%E3%81%93%E3%81%A8%E3%81%86%E3%81%B5/dp/4758069778/?language=ja_JP',
+    name: "Amazon (Japanese)",
+    url: "https://www.amazon.co.jp/%E3%81%8A%E5%85%84%E3%81%A1%E3%82%83%E3%82%93%E3%81%AF%E3%81%8A%E3%81%97%E3%81%BE%E3%81%84-6-ID%E3%82%B3%E3%83%9F%E3%83%83%E3%82%AF%E3%82%B9-%E3%81%AD%E3%81%93%E3%81%A8%E3%81%86%E3%81%B5/dp/4758069778/?language=ja_JP",
     currentSelectors: [
-      '#navbar',
-      '#productTitle',
-      '#detailBullets_feature_div',
-      "[href*='ref=dp_byline_cont_book']"
-    ]
+      "#navbar",
+      "#productTitle",
+      "#detailBullets_feature_div",
+      "[href*='ref=dp_byline_cont_book']",
+    ],
   };
 
-  test(`Debug DOM structure and selectors: ${amazonSite.name}`, async ({ page }) => {
+  test(`Debug DOM structure and selectors: ${amazonSite.name}`, async ({
+    page,
+  }) => {
     console.log(`\n🔍 Debugging ${amazonSite.name}: ${amazonSite.url}`);
     console.log(`🎭 Applying stealth mode to avoid bot detection...`);
 
@@ -39,7 +41,9 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
       // 1. ページの基本情報
       const htmlSnippet = await page.content();
       console.log(`   HTML Length: ${htmlSnippet.length} characters`);
-      console.log(`   HTML Preview (first 1000 chars): ${htmlSnippet.substring(0, 1000)}...`);
+      console.log(
+        `   HTML Preview (first 1000 chars): ${htmlSnippet.substring(0, 1000)}...`,
+      );
 
       // 2. 現在のセレクタのチェック
       console.log(`\n🔍 CHECKING CURRENT SELECTORS:`);
@@ -49,7 +53,7 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
           const count = await element.count();
           if (count > 0) {
             const visible = await element.isVisible().catch(() => false);
-            const text = await element.textContent().catch(() => '');
+            const text = await element.textContent().catch(() => "");
             console.log(`   ✅ ${selector}: Found (visible: ${visible})`);
             if (text && text.length < 100) {
               console.log(`      Text: "${text.trim()}"`);
@@ -58,10 +62,11 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
             console.log(`   ❌ ${selector}: NOT FOUND`);
           }
         } catch (error) {
-          const errorMsg = error instanceof Error ? error.message : String(error);
+          const errorMsg =
+            error instanceof Error ? error.message : String(error);
           console.log(`   ❌ ${selector}: ERROR - ${errorMsg}`);
           if (error instanceof Error && error.stack) {
-            console.log(`      Stack: ${error.stack.split('\n')[1]?.trim()}`);
+            console.log(`      Stack: ${error.stack.split("\n")[1]?.trim()}`);
           }
         }
       }
@@ -71,12 +76,12 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
 
       // ナビゲーションバー関連
       const navSelectors = [
-        '#navbar',
-        '#nav-main',
-        'header',
+        "#navbar",
+        "#nav-main",
+        "header",
         '[role="navigation"]',
-        '.nav-container',
-        '#skiplink'
+        ".nav-container",
+        "#skiplink",
       ];
 
       console.log(`\n   📍 Navigation Bar Alternatives:`);
@@ -93,11 +98,11 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
 
       // タイトル関連
       const titleSelectors = [
-        '#productTitle',
-        '#title',
-        'h1',
+        "#productTitle",
+        "#title",
+        "h1",
         '[data-feature-name="title"]',
-        '.product-title'
+        ".product-title",
       ];
 
       console.log(`\n   📍 Title Alternatives:`);
@@ -105,8 +110,14 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
         try {
           const count = await page.locator(selector).count();
           if (count > 0) {
-            const text = await page.locator(selector).first().textContent().catch(() => '');
-            console.log(`      ✅ ${selector}: Found (${count} elements) - "${text?.trim().substring(0, 50)}..."`);
+            const text = await page
+              .locator(selector)
+              .first()
+              .textContent()
+              .catch(() => "");
+            console.log(
+              `      ✅ ${selector}: Found (${count} elements) - "${text?.trim().substring(0, 50)}..."`,
+            );
           }
         } catch (error) {
           // Skip
@@ -115,13 +126,13 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
 
       // 商品詳細関連
       const detailSelectors = [
-        '#detailBullets_feature_div',
-        '#detailBulletsWrapper_feature_div',
-        '#detailBullets',
-        '.detail-bullets',
-        '#productDetails_feature_div',
-        '#productDetails_techSpec_section_1',
-        '#productDetails_detailBullets_sections1'
+        "#detailBullets_feature_div",
+        "#detailBulletsWrapper_feature_div",
+        "#detailBullets",
+        ".detail-bullets",
+        "#productDetails_feature_div",
+        "#productDetails_techSpec_section_1",
+        "#productDetails_detailBullets_sections1",
       ];
 
       console.log(`\n   📍 Product Details Alternatives:`);
@@ -142,7 +153,7 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
         ".author",
         ".contributorNameID",
         "[data-feature-name='bylineInfo']",
-        ".a-section.a-spacing-none.author"
+        ".a-section.a-spacing-none.author",
       ];
 
       console.log(`\n   📍 Author Information Alternatives:`);
@@ -150,8 +161,14 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
         try {
           const count = await page.locator(selector).count();
           if (count > 0) {
-            const text = await page.locator(selector).first().textContent().catch(() => '');
-            console.log(`      ✅ ${selector}: Found (${count} elements) - "${text?.trim().substring(0, 50)}..."`);
+            const text = await page
+              .locator(selector)
+              .first()
+              .textContent()
+              .catch(() => "");
+            console.log(
+              `      ✅ ${selector}: Found (${count} elements) - "${text?.trim().substring(0, 50)}..."`,
+            );
           }
         } catch (error) {
           // Skip
@@ -161,39 +178,48 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
       // 4. ページに存在する主要なID要素をリストアップ
       console.log(`\n📑 MAJOR ID ELEMENTS ON PAGE:`);
       const idElements = await page.evaluate(() => {
-        const elements = Array.from(document.querySelectorAll('[id]'));
+        const elements = Array.from(document.querySelectorAll("[id]"));
         return elements
-          .filter(el => el.id && !el.id.startsWith('nav-') && !el.id.includes('carousel'))
+          .filter(
+            (el) =>
+              el.id && !el.id.startsWith("nav-") && !el.id.includes("carousel"),
+          )
           .slice(0, 30)
-          .map(el => ({
+          .map((el) => ({
             id: el.id,
             tagName: el.tagName,
-            className: el.className
+            className: el.className,
           }));
       });
 
-      idElements.forEach(el => {
-        console.log(`   #${el.id} (${el.tagName}${el.className ? ', class: ' + el.className : ''})`);
+      idElements.forEach((el) => {
+        console.log(
+          `   #${el.id} (${el.tagName}${el.className ? ", class: " + el.className : ""})`,
+        );
       });
 
       // 5. ボット検証やCAPTCHAの確認
       console.log(`\n🤖 CHECKING FOR BOT DETECTION:`);
       const botIndicators = [
-        'Sorry, we just need to make sure',
-        'Enter the characters you see',
-        'CAPTCHA',
-        'Robot Check',
-        'ロボットでは'
+        "Sorry, we just need to make sure",
+        "Enter the characters you see",
+        "CAPTCHA",
+        "Robot Check",
+        "ロボットでは",
       ];
 
-      const pageText = await page.evaluate(() => document.body.textContent || '');
-      const foundIndicators = botIndicators.filter(indicator =>
-        pageText.toLowerCase().includes(indicator.toLowerCase())
+      const pageText = await page.evaluate(
+        () => document.body.textContent || "",
+      );
+      const foundIndicators = botIndicators.filter((indicator) =>
+        pageText.toLowerCase().includes(indicator.toLowerCase()),
       );
 
       if (foundIndicators.length > 0) {
         console.log(`   ⚠️ POTENTIAL BOT DETECTION FOUND:`);
-        foundIndicators.forEach(indicator => console.log(`      - ${indicator}`));
+        foundIndicators.forEach((indicator) =>
+          console.log(`      - ${indicator}`),
+        );
       } else {
         console.log(`   ✅ No bot detection indicators found`);
       }
@@ -201,23 +227,28 @@ describeMethod('Amazon (Japanese) DOM Structure Debug', () => {
       // デバッグ用スクリーンショットを保存
       console.log(`\n📸 SAVING DEBUG SCREENSHOT:`);
       try {
-        const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
         await page.screenshot({
           path: `amazon-debug-screenshot-${timestamp}.png`,
-          fullPage: true
+          fullPage: true,
         });
-        console.log(`   ✅ Screenshot saved: amazon-debug-screenshot-${timestamp}.png`);
+        console.log(
+          `   ✅ Screenshot saved: amazon-debug-screenshot-${timestamp}.png`,
+        );
       } catch (error) {
-        console.log(`   ⚠️ Failed to save screenshot: ${error instanceof Error ? error.message : 'Unknown'}`);
+        console.log(
+          `   ⚠️ Failed to save screenshot: ${error instanceof Error ? error.message : "Unknown"}`,
+        );
       }
 
       // デバッグテストは情報収集が目的なので、エラーが発生しても成功とする
       // HTTPステータスの記録のみ行い、成功/失敗は判定しない
       expect(true).toBe(true);
-
     } catch (error) {
       // デバッグテストは情報収集が目的なので、エラーが発生しても成功とする
-      console.log(`❌ Test failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      console.log(
+        `❌ Test failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
       expect(true).toBe(true);
     }
   });

--- a/src/__tests__/large/monitoring/fanza-debug.test.ts
+++ b/src/__tests__/large/monitoring/fanza-debug.test.ts
@@ -1,30 +1,30 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
 // CI環境でのFANZA年齢認証問題の詳細デバッグ用テスト
 // 通常は無効化しているが、専用デバッグワークフローでは実行される
-const isDebugWorkflow = process.env.GITHUB_WORKFLOW === 'Debug CI Environment';
+const isDebugWorkflow = process.env.GITHUB_WORKFLOW === "Debug CI Environment";
 const describeMethod = isDebugWorkflow ? test.describe : test.describe.skip;
 
-describeMethod('FANZA Age Verification Debug', () => {
+describeMethod("FANZA Age Verification Debug", () => {
   const failingSites = [
     {
-      name: 'FANZA Video',
-      url: 'https://video.dmm.co.jp/av/content/?id=apns00240',
-      expectedContent: 'h1, table'
+      name: "FANZA Video",
+      url: "https://video.dmm.co.jp/av/content/?id=apns00240",
+      expectedContent: "h1, table",
     },
     {
-      name: 'FANZA Doujin',
-      url: 'https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_335698/',
-      expectedContent: '.productTitle__txt, h1'
+      name: "FANZA Doujin",
+      url: "https://www.dmm.co.jp/dc/doujin/-/detail/=/cid=d_335698/",
+      expectedContent: ".productTitle__txt, h1",
     },
     {
-      name: 'FANZA Books',
-      url: 'https://book.dmm.co.jp/product/4425627/b425aakkg00576/',
-      expectedContent: '.css-1omcat5, dl'
-    }
+      name: "FANZA Books",
+      url: "https://book.dmm.co.jp/product/4425627/b425aakkg00576/",
+      expectedContent: ".css-1omcat5, dl",
+    },
   ];
 
-  failingSites.forEach(site => {
+  failingSites.forEach((site) => {
     test(`Debug age verification: ${site.name}`, async ({ page }) => {
       const isCI = !!process.env.CI;
 
@@ -33,8 +33,8 @@ describeMethod('FANZA Age Verification Debug', () => {
       try {
         // 初期アクセス
         const response = await page.goto(site.url, {
-          waitUntil: 'commit',
-          timeout: 30000
+          waitUntil: "commit",
+          timeout: 30000,
         });
 
         const status = response?.status() || 0;
@@ -47,7 +47,7 @@ describeMethod('FANZA Age Verification Debug', () => {
         console.log(`   Title: ${title}`);
 
         // 年齢認証ページかどうか確認
-        if (finalUrl.includes('age_check') || title.includes('年齢認証')) {
+        if (finalUrl.includes("age_check") || title.includes("年齢認証")) {
           console.log(`\n🔞 AGE VERIFICATION PAGE DETECTED`);
 
           // 詳細なDOM分析
@@ -60,22 +60,28 @@ describeMethod('FANZA Age Verification Debug', () => {
 
           // 2. すべてのボタン要素を検索
           const buttons = await page.evaluate(() => {
-            const buttonElements = Array.from(document.querySelectorAll('button, input[type="button"], input[type="submit"], a[role="button"]'));
-            return buttonElements.map(btn => ({
+            const buttonElements = Array.from(
+              document.querySelectorAll(
+                'button, input[type="button"], input[type="submit"], a[role="button"]',
+              ),
+            );
+            return buttonElements.map((btn) => ({
               tagName: btn.tagName,
-              type: btn.getAttribute('type'),
-              textContent: btn.textContent?.trim() || '',
+              type: btn.getAttribute("type"),
+              textContent: btn.textContent?.trim() || "",
               innerHTML: btn.innerHTML,
               className: btn.className,
               id: btn.id,
-              role: btn.getAttribute('role'),
-              href: btn.getAttribute('href')
+              role: btn.getAttribute("role"),
+              href: btn.getAttribute("href"),
             }));
           });
 
           console.log(`\n🔘 BUTTON ELEMENTS FOUND (${buttons.length}):`);
           buttons.forEach((btn, idx) => {
-            console.log(`   [${idx}] ${btn.tagName}: "${btn.textContent}" (class: "${btn.className}", id: "${btn.id}")`);
+            console.log(
+              `   [${idx}] ${btn.tagName}: "${btn.textContent}" (class: "${btn.className}", id: "${btn.id}")`,
+            );
             if (btn.innerHTML && btn.innerHTML !== btn.textContent) {
               console.log(`       HTML: ${btn.innerHTML}`);
             }
@@ -83,50 +89,67 @@ describeMethod('FANZA Age Verification Debug', () => {
 
           // 3. テキストベースでのボタン検索
           const textMatches = await page.evaluate(() => {
-            const allElements = Array.from(document.querySelectorAll('*'));
-            const possibleButtons = allElements.filter(el => {
-              const text = el.textContent?.toLowerCase() || '';
-              return text.includes('yes') || text.includes('enter') || text.includes('agree') ||
-                     text.includes('はい') || text.includes('同意') || text.includes('18') ||
-                     text.includes('adult') || text.includes('confirm');
+            const allElements = Array.from(document.querySelectorAll("*"));
+            const possibleButtons = allElements.filter((el) => {
+              const text = el.textContent?.toLowerCase() || "";
+              return (
+                text.includes("yes") ||
+                text.includes("enter") ||
+                text.includes("agree") ||
+                text.includes("はい") ||
+                text.includes("同意") ||
+                text.includes("18") ||
+                text.includes("adult") ||
+                text.includes("confirm")
+              );
             });
 
-            return possibleButtons.map(el => ({
+            return possibleButtons.map((el) => ({
               tagName: el.tagName,
-              textContent: el.textContent?.trim() || '',
+              textContent: el.textContent?.trim() || "",
               className: el.className,
               id: el.id,
-              clickable: el.tagName === 'BUTTON' || el.tagName === 'A' ||
-                         el.getAttribute('role') === 'button' ||
-                         el.getAttribute('type') === 'submit'
+              clickable:
+                el.tagName === "BUTTON" ||
+                el.tagName === "A" ||
+                el.getAttribute("role") === "button" ||
+                el.getAttribute("type") === "submit",
             }));
           });
 
           console.log(`\n🎯 TEXT-BASED MATCHES (${textMatches.length}):`);
           textMatches.forEach((match, idx) => {
-            console.log(`   [${idx}] ${match.tagName}: "${match.textContent}" (clickable: ${match.clickable})`);
+            console.log(
+              `   [${idx}] ${match.tagName}: "${match.textContent}" (clickable: ${match.clickable})`,
+            );
           });
 
           // 4. フォーム要素の検索
           const forms = await page.evaluate(() => {
-            const formElements = Array.from(document.querySelectorAll('form'));
-            return formElements.map(form => ({
+            const formElements = Array.from(document.querySelectorAll("form"));
+            return formElements.map((form) => ({
               action: form.action,
               method: form.method,
-              inputs: Array.from(form.querySelectorAll('input')).map(input => ({
-                type: input.type,
-                name: input.name,
-                value: input.value,
-                id: input.id
-              }))
+              inputs: Array.from(form.querySelectorAll("input")).map(
+                (input) => ({
+                  type: input.type,
+                  name: input.name,
+                  value: input.value,
+                  id: input.id,
+                }),
+              ),
             }));
           });
 
           console.log(`\n📝 FORM ELEMENTS (${forms.length}):`);
           forms.forEach((form, idx) => {
-            console.log(`   [${idx}] Action: ${form.action}, Method: ${form.method}`);
+            console.log(
+              `   [${idx}] Action: ${form.action}, Method: ${form.method}`,
+            );
             form.inputs.forEach((input, inputIdx) => {
-              console.log(`       Input[${inputIdx}]: ${input.type} (name: "${input.name}", value: "${input.value}")`);
+              console.log(
+                `       Input[${inputIdx}]: ${input.type} (name: "${input.name}", value: "${input.value}")`,
+              );
             });
           });
 
@@ -134,12 +157,12 @@ describeMethod('FANZA Age Verification Debug', () => {
           console.log(`\n🧪 ATTEMPTING AGE VERIFICATION:`);
 
           const ageCheckSelectors = [
-            'text=はい',
-            'text=Yes',
-            'text=Enter',
-            'text=I am 18 or older',
-            'text=Agree',
-            'text=Continue',
+            "text=はい",
+            "text=Yes",
+            "text=Enter",
+            "text=I am 18 or older",
+            "text=Agree",
+            "text=Continue",
             'button:has-text("はい")',
             'button:has-text("Yes")',
             'button:has-text("Enter")',
@@ -147,7 +170,7 @@ describeMethod('FANZA Age Verification Debug', () => {
             'input[value="Yes"]',
             'input[type="submit"]',
             '[class*="yes"], [class*="agree"], [class*="enter"]',
-            'a[href*="age_check"]'
+            'a[href*="age_check"]',
           ];
 
           let successfulSelector = null;
@@ -159,15 +182,17 @@ describeMethod('FANZA Age Verification Debug', () => {
                 successfulSelector = selector;
 
                 // 要素の詳細情報を取得
-                const elementInfo = await element.evaluate(el => ({
+                const elementInfo = await element.evaluate((el) => ({
                   tagName: el.tagName,
                   textContent: el.textContent,
                   className: el.className,
                   id: el.id,
-                  href: el.getAttribute('href'),
-                  type: el.getAttribute('type')
+                  href: el.getAttribute("href"),
+                  type: el.getAttribute("type"),
                 }));
-                console.log(`      Element details: ${JSON.stringify(elementInfo)}`);
+                console.log(
+                  `      Element details: ${JSON.stringify(elementInfo)}`,
+                );
                 break;
               }
             } catch (error) {
@@ -186,31 +211,36 @@ describeMethod('FANZA Age Verification Debug', () => {
               console.log(`   After click - URL: ${newUrl}`);
               console.log(`   After click - Title: ${newTitle}`);
 
-              if (!newUrl.includes('age_check')) {
+              if (!newUrl.includes("age_check")) {
                 console.log(`   ✅ Age verification succeeded!`);
               } else {
                 console.log(`   ❌ Still on age verification page`);
               }
             } catch (error) {
-              console.log(`   ❌ Click failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+              console.log(
+                `   ❌ Click failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+              );
             }
           } else {
             console.log(`   ❌ No working age verification selector found`);
           }
-
-        } else if (finalUrl.includes('login') || title.includes('ログイン')) {
+        } else if (finalUrl.includes("login") || title.includes("ログイン")) {
           console.log(`\n🔑 LOGIN PAGE DETECTED`);
-          console.log(`   This explains why FANZA Books fails - requires login from overseas IP`);
-
+          console.log(
+            `   This explains why FANZA Books fails - requires login from overseas IP`,
+          );
         } else {
-          console.log(`\n✅ DIRECT ACCESS - No age verification or login required`);
+          console.log(
+            `\n✅ DIRECT ACCESS - No age verification or login required`,
+          );
         }
 
         // テストは常に成功（情報収集目的）
         expect(status).toBeGreaterThan(0);
-
       } catch (error) {
-        console.log(`❌ Test failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+        console.log(
+          `❌ Test failed: ${error instanceof Error ? error.message : "Unknown error"}`,
+        );
         expect(error).toBeDefined();
       }
     });

--- a/src/__tests__/large/monitoring/scraping-logic.test.ts
+++ b/src/__tests__/large/monitoring/scraping-logic.test.ts
@@ -1,31 +1,34 @@
-import { test, expect } from '@playwright/test';
-import { scrapeFanzaVideoData } from '../../../scraping/fanza-video-scraper';
-import { scrapeFanzaDoujinData } from '../../../scraping/fanza-doujin-scraper';
-import { scrapeFanzaBooksData } from '../../../scraping/fanza-books-scraper';
-import { scrapeAmazonData } from '../../../scraping/amazon-scraper';
-import { scrapeBookWalkerData } from '../../../scraping/bookwalker-scraper';
-import { scrapeDLsiteData } from '../../../scraping/dlsite-scraper';
-import { scrapeDLsiteBooksData } from '../../../scraping/dlsite-books-scraper';
-import { scrapeMelonbooksData } from '../../../scraping/melonbooks-scraper';
-import { scrapeDLsiteManiaxData } from '../../../scraping/dlsite-maniax-scraper';
-import { scrapeFc2ContentMarketData } from '../../../scraping/fc2-content-market-scraper';
-import { scrapeSurugayaData } from '../../../scraping/surugaya-scraper';
-import { scrapeToranoanaData } from '../../../scraping/toranoana-scraper';
-import { scrapeFanzaAnimeData } from '../../../scraping/fanza-anime-scraper';
+import { test, expect } from "@playwright/test";
+import { scrapeFanzaVideoData } from "../../../scraping/fanza-video-scraper";
+import { scrapeFanzaDoujinData } from "../../../scraping/fanza-doujin-scraper";
+import { scrapeFanzaBooksData } from "../../../scraping/fanza-books-scraper";
+import { scrapeAmazonData } from "../../../scraping/amazon-scraper";
+import { scrapeBookWalkerData } from "../../../scraping/bookwalker-scraper";
+import { scrapeDLsiteData } from "../../../scraping/dlsite-scraper";
+import { scrapeDLsiteBooksData } from "../../../scraping/dlsite-books-scraper";
+import { scrapeMelonbooksData } from "../../../scraping/melonbooks-scraper";
+import { scrapeDLsiteManiaxData } from "../../../scraping/dlsite-maniax-scraper";
+import { scrapeFc2ContentMarketData } from "../../../scraping/fc2-content-market-scraper";
+import { scrapeSurugayaData } from "../../../scraping/surugaya-scraper";
+import { scrapeToranoanaData } from "../../../scraping/toranoana-scraper";
+import { scrapeFanzaAnimeData } from "../../../scraping/fanza-anime-scraper";
 import {
   staticSites,
   spaSites,
   handleAgeVerification,
-  waitForSPAContent
-} from './shared';
+  waitForSPAContent,
+} from "./shared";
 
 const allSites = [...staticSites, ...spaSites];
 
 // FANZA Video専用のスクレイピングロジックテスト
-test.describe('FANZA Video Scraping Logic', () => {
-  const siteConfig = spaSites.find(site => site.service === 'FANZA Video');
+test.describe("FANZA Video Scraping Logic", () => {
+  const siteConfig = spaSites.find((site) => site.service === "FANZA Video");
 
-  test('should successfully run FANZA Video scraping logic', async ({ page, browserName }) => {
+  test("should successfully run FANZA Video scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
@@ -38,7 +41,7 @@ test.describe('FANZA Video Scraping Logic', () => {
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeFanzaVideoData = ${scrapeFanzaVideoData.toString()};`
+      content: `window.scrapeFanzaVideoData = ${scrapeFanzaVideoData.toString()};`,
     });
 
     // 実際のFANZAVideoスクレイピング関数をページ内で実行
@@ -50,21 +53,28 @@ test.describe('FANZA Video Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('video.dmm.co.jp');
+    expect(scrapingResult.url).toContain("video.dmm.co.jp");
 
     console.log(`✓ Video Title: ${scrapingResult.title}`);
-    console.log(`✓ Video Actress: ${scrapingResult.actress ? scrapingResult.actress.join(', ') : 'Not found'}`);
-    console.log(`✓ Video Director: ${scrapingResult.director || 'Not found'}`);
-    console.log(`✓ Video Label: ${scrapingResult.label || 'Not found'}`);
-    console.log(`✓ Video Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ Video Actress: ${scrapingResult.actress ? scrapingResult.actress.join(", ") : "Not found"}`,
+    );
+    console.log(`✓ Video Director: ${scrapingResult.director || "Not found"}`);
+    console.log(`✓ Video Label: ${scrapingResult.label || "Not found"}`);
+    console.log(
+      `✓ Video Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // FANZA Doujin専用のスクレイピングロジックテスト
-test.describe('FANZA Doujin Scraping Logic', () => {
-  const siteConfig = spaSites.find(site => site.service === 'FANZA Doujin');
+test.describe("FANZA Doujin Scraping Logic", () => {
+  const siteConfig = spaSites.find((site) => site.service === "FANZA Doujin");
 
-  test('should successfully run FANZA Doujin scraping logic', async ({ page, browserName }) => {
+  test("should successfully run FANZA Doujin scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
@@ -77,7 +87,7 @@ test.describe('FANZA Doujin Scraping Logic', () => {
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeFanzaDoujinData = ${scrapeFanzaDoujinData.toString()};`
+      content: `window.scrapeFanzaDoujinData = ${scrapeFanzaDoujinData.toString()};`,
     });
 
     // 実際のFANZADoujinスクレイピング関数をページ内で実行
@@ -89,20 +99,27 @@ test.describe('FANZA Doujin Scraping Logic', () => {
     expect(doujinScrapingResult.title).toBeTruthy();
     expect(doujinScrapingResult.title.length).toBeGreaterThan(0);
     expect(doujinScrapingResult.circleName).toBeTruthy();
-    expect(doujinScrapingResult.url).toContain('dmm.co.jp/dc/doujin');
+    expect(doujinScrapingResult.url).toContain("dmm.co.jp/dc/doujin");
 
     console.log(`✓ Doujin Title: ${doujinScrapingResult.title}`);
     console.log(`✓ Circle Name: ${doujinScrapingResult.circleName}`);
-    console.log(`✓ Authors: ${doujinScrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ Published Date: ${doujinScrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ Authors: ${doujinScrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ Published Date: ${doujinScrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // FANZA Books専用のスクレイピングロジックテスト
-test.describe('FANZA Books Scraping Logic', () => {
-  const siteConfig = spaSites.find(site => site.service === 'FANZA Books');
+test.describe("FANZA Books Scraping Logic", () => {
+  const siteConfig = spaSites.find((site) => site.service === "FANZA Books");
 
-  test('should successfully run FANZA Books scraping logic', async ({ page, browserName }) => {
+  test("should successfully run FANZA Books scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
@@ -117,7 +134,7 @@ test.describe('FANZA Books Scraping Logic', () => {
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeFanzaBooksData = ${scrapeFanzaBooksData.toString()};`
+      content: `window.scrapeFanzaBooksData = ${scrapeFanzaBooksData.toString()};`,
     });
 
     // 実際のFANZABooksスクレイピング関数をページ内で実行
@@ -129,28 +146,37 @@ test.describe('FANZA Books Scraping Logic', () => {
     expect(booksScrapingResult).toBeTruthy();
     expect(booksScrapingResult.title).toBeTruthy();
     expect(booksScrapingResult.title.length).toBeGreaterThan(0);
-    expect(booksScrapingResult.url).toContain('book.dmm.co.jp');
+    expect(booksScrapingResult.url).toContain("book.dmm.co.jp");
 
     console.log(`✓ Book Title: ${booksScrapingResult.title}`);
-    console.log(`✓ Authors: ${booksScrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ Publisher: ${booksScrapingResult.publisher || 'Not found'}`);
-    console.log(`✓ Label: ${booksScrapingResult.label || 'Not found'}`);
-    console.log(`✓ Published Date: ${booksScrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ Authors: ${booksScrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(`✓ Publisher: ${booksScrapingResult.publisher || "Not found"}`);
+    console.log(`✓ Label: ${booksScrapingResult.label || "Not found"}`);
+    console.log(
+      `✓ Published Date: ${booksScrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // Amazon scraping logic test (both English and Japanese)
-test.describe('Amazon Scraping Logic', () => {
-  const amazonSites = staticSites.filter(site => site.service.startsWith('Amazon'));
+test.describe("Amazon Scraping Logic", () => {
+  const amazonSites = staticSites.filter((site) =>
+    site.service.startsWith("Amazon"),
+  );
 
-  amazonSites.forEach(siteConfig => {
-    test(`should successfully run Amazon scraping logic - ${siteConfig.service}`, async ({ page, browserName }) => {
+  amazonSites.forEach((siteConfig) => {
+    test(`should successfully run Amazon scraping logic - ${siteConfig.service}`, async ({
+      page,
+      browserName,
+    }) => {
       await page.goto(siteConfig.url);
-      await page.waitForLoadState('load');
+      await page.waitForLoadState("load");
 
       // 関数をページに注入
       await page.addScriptTag({
-        content: `window.scrapeAmazonData = ${scrapeAmazonData.toString()};`
+        content: `window.scrapeAmazonData = ${scrapeAmazonData.toString()};`,
       });
 
       // 実際のAmazonスクレイピング関数をページ内で実行
@@ -162,32 +188,41 @@ test.describe('Amazon Scraping Logic', () => {
       expect(scrapingResult).toBeTruthy();
       expect(scrapingResult.title).toBeTruthy();
       expect(scrapingResult.title.length).toBeGreaterThan(0);
-      expect(scrapingResult.url).toContain('amazon.co.jp');
+      expect(scrapingResult.url).toContain("amazon.co.jp");
 
       console.log(`✓ Amazon Title: ${scrapingResult.title}`);
-      console.log(`✓ Amazon Authors: ${scrapingResult.authors.join(', ') || 'Not found'}`);
-      console.log(`✓ Amazon Publisher: ${scrapingResult.publisher || 'Not found'}`);
-      console.log(`✓ Amazon Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+      console.log(
+        `✓ Amazon Authors: ${scrapingResult.authors.join(", ") || "Not found"}`,
+      );
+      console.log(
+        `✓ Amazon Publisher: ${scrapingResult.publisher || "Not found"}`,
+      );
+      console.log(
+        `✓ Amazon Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+      );
     });
   });
 });
 
 // BookWalker scraping logic test
-test.describe('BookWalker Scraping Logic', () => {
-  const siteConfig = staticSites.find(site => site.service === 'BookWalker');
+test.describe("BookWalker Scraping Logic", () => {
+  const siteConfig = staticSites.find((site) => site.service === "BookWalker");
 
-  test('should successfully run BookWalker scraping logic', async ({ page, browserName }) => {
+  test("should successfully run BookWalker scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
     if (siteConfig.hasAgeVerification) {
       await handleAgeVerification(page);
     }
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeBookWalkerData = ${scrapeBookWalkerData.toString()};`
+      content: `window.scrapeBookWalkerData = ${scrapeBookWalkerData.toString()};`,
     });
 
     // 実際のBookWalkerスクレイピング関数をページ内で実行
@@ -199,32 +234,41 @@ test.describe('BookWalker Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('bookwalker.jp');
+    expect(scrapingResult.url).toContain("bookwalker.jp");
 
     console.log(`✓ BookWalker Title: ${scrapingResult.title}`);
-    console.log(`✓ BookWalker Authors: ${scrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ BookWalker Publisher: ${scrapingResult.publisher || 'Not found'}`);
-    console.log(`✓ BookWalker Label: ${scrapingResult.label || 'Not found'}`);
-    console.log(`✓ BookWalker Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ BookWalker Authors: ${scrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ BookWalker Publisher: ${scrapingResult.publisher || "Not found"}`,
+    );
+    console.log(`✓ BookWalker Label: ${scrapingResult.label || "Not found"}`);
+    console.log(
+      `✓ BookWalker Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // DLsite scraping logic test
-test.describe('DLsite Scraping Logic', () => {
-  const siteConfig = staticSites.find(site => site.service === 'DLsite');
+test.describe("DLsite Scraping Logic", () => {
+  const siteConfig = staticSites.find((site) => site.service === "DLsite");
 
-  test('should successfully run DLsite scraping logic', async ({ page, browserName }) => {
+  test("should successfully run DLsite scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
     if (siteConfig.hasAgeVerification) {
       await handleAgeVerification(page);
     }
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeDLsiteData = ${scrapeDLsiteData.toString()};`
+      content: `window.scrapeDLsiteData = ${scrapeDLsiteData.toString()};`,
     });
 
     // 実際のDLsiteスクレイピング関数をページ内で実行
@@ -236,33 +280,42 @@ test.describe('DLsite Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('dlsite.com');
+    expect(scrapingResult.url).toContain("dlsite.com");
 
     console.log(`✓ DLsite Title: ${scrapingResult.title}`);
-    console.log(`✓ DLsite Authors: ${scrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ DLsite Circle: ${scrapingResult.circleName || 'Not found'}`);
-    console.log(`✓ DLsite Voice Actors: ${scrapingResult.voiceActors.join(', ') || 'Not found'}`);
+    console.log(
+      `✓ DLsite Authors: ${scrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(`✓ DLsite Circle: ${scrapingResult.circleName || "Not found"}`);
+    console.log(
+      `✓ DLsite Voice Actors: ${scrapingResult.voiceActors.join(", ") || "Not found"}`,
+    );
     console.log(`✓ DLsite Product Type: ${scrapingResult.productType}`);
-    console.log(`✓ DLsite Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ DLsite Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // DLsiteBooks scraping logic test
-test.describe('DLsiteBooks Scraping Logic', () => {
-  const siteConfig = staticSites.find(site => site.service === 'DLsiteBooks');
+test.describe("DLsiteBooks Scraping Logic", () => {
+  const siteConfig = staticSites.find((site) => site.service === "DLsiteBooks");
 
-  test('should successfully run DLsiteBooks scraping logic', async ({ page, browserName }) => {
+  test("should successfully run DLsiteBooks scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
     if (siteConfig.hasAgeVerification) {
       await handleAgeVerification(page);
     }
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeDLsiteBooksData = ${scrapeDLsiteBooksData.toString()};`
+      content: `window.scrapeDLsiteBooksData = ${scrapeDLsiteBooksData.toString()};`,
     });
 
     // 実際のDLsiteBooksスクレイピング関数をページ内で実行
@@ -274,29 +327,38 @@ test.describe('DLsiteBooks Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('dlsite.com');
+    expect(scrapingResult.url).toContain("dlsite.com");
 
     console.log(`✓ DLsiteBooks Title: ${scrapingResult.title}`);
-    console.log(`✓ DLsiteBooks Authors: ${scrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ DLsiteBooks Publisher: ${scrapingResult.publisher || 'Not found'}`);
-    console.log(`✓ DLsiteBooks Label: ${scrapingResult.label || 'Not found'}`);
-    console.log(`✓ DLsiteBooks Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ DLsiteBooks Authors: ${scrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ DLsiteBooks Publisher: ${scrapingResult.publisher || "Not found"}`,
+    );
+    console.log(`✓ DLsiteBooks Label: ${scrapingResult.label || "Not found"}`);
+    console.log(
+      `✓ DLsiteBooks Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // Melonbooks scraping logic test
-test.describe('Melonbooks Scraping Logic', () => {
-  const siteConfig = staticSites.find(site => site.service === 'Melonbooks');
+test.describe("Melonbooks Scraping Logic", () => {
+  const siteConfig = staticSites.find((site) => site.service === "Melonbooks");
 
-  test('should successfully run Melonbooks scraping logic', async ({ page, browserName }) => {
+  test("should successfully run Melonbooks scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeMelonbooksData = ${scrapeMelonbooksData.toString()};`
+      content: `window.scrapeMelonbooksData = ${scrapeMelonbooksData.toString()};`,
     });
 
     // 実際のMelonbooksスクレイピング関数をページ内で実行
@@ -308,30 +370,45 @@ test.describe('Melonbooks Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('melonbooks.co.jp');
+    expect(scrapingResult.url).toContain("melonbooks.co.jp");
 
     console.log(`✓ Melonbooks Title: ${scrapingResult.title}`);
-    console.log(`✓ Melonbooks Authors: ${scrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ Melonbooks Circle: ${scrapingResult.circleName || 'Not found'}`);
-    console.log(`✓ Melonbooks Genre: ${scrapingResult.genre.join(', ') || 'Not found'}`);
-    console.log(`✓ Melonbooks Event: ${scrapingResult.eventName || 'Not found'}`);
-    console.log(`✓ Melonbooks Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ Melonbooks Authors: ${scrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ Melonbooks Circle: ${scrapingResult.circleName || "Not found"}`,
+    );
+    console.log(
+      `✓ Melonbooks Genre: ${scrapingResult.genre.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ Melonbooks Event: ${scrapingResult.eventName || "Not found"}`,
+    );
+    console.log(
+      `✓ Melonbooks Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // DLsiteManiax scraping logic test
-test.describe('DLsiteManiax Scraping Logic', () => {
-  const siteConfig = staticSites.find(site => site.service === 'DLsiteManiax');
+test.describe("DLsiteManiax Scraping Logic", () => {
+  const siteConfig = staticSites.find(
+    (site) => site.service === "DLsiteManiax",
+  );
 
-  test('should successfully run DLsiteManiax scraping logic', async ({ page, browserName }) => {
+  test("should successfully run DLsiteManiax scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeDLsiteManiaxData = ${scrapeDLsiteManiaxData.toString()};`
+      content: `window.scrapeDLsiteManiaxData = ${scrapeDLsiteManiaxData.toString()};`,
     });
 
     // 実際のDLsiteManiaxスクレイピング関数をページ内で実行
@@ -343,30 +420,43 @@ test.describe('DLsiteManiax Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('dlsite.com');
+    expect(scrapingResult.url).toContain("dlsite.com");
 
     console.log(`✓ DLsiteManiax Title: ${scrapingResult.title}`);
-    console.log(`✓ DLsiteManiax Type: ${scrapingResult.type || 'Not found'}`);
-    console.log(`✓ DLsiteManiax Authors: ${scrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ DLsiteManiax Circle: ${scrapingResult.circleName || 'Not found'}`);
-    console.log(`✓ DLsiteManiax Voice Actors: ${scrapingResult.voiceActors.join(', ') || 'Not found'}`);
-    console.log(`✓ DLsiteManiax Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(`✓ DLsiteManiax Type: ${scrapingResult.type || "Not found"}`);
+    console.log(
+      `✓ DLsiteManiax Authors: ${scrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ DLsiteManiax Circle: ${scrapingResult.circleName || "Not found"}`,
+    );
+    console.log(
+      `✓ DLsiteManiax Voice Actors: ${scrapingResult.voiceActors.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ DLsiteManiax Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // Fc2ContentMarket scraping logic test
-test.describe('Fc2ContentMarket Scraping Logic', () => {
-  const siteConfig = staticSites.find(site => site.service === 'Fc2ContentMarket');
+test.describe("Fc2ContentMarket Scraping Logic", () => {
+  const siteConfig = staticSites.find(
+    (site) => site.service === "Fc2ContentMarket",
+  );
 
-  test('should successfully run Fc2ContentMarket scraping logic', async ({ page, browserName }) => {
+  test("should successfully run Fc2ContentMarket scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeFc2ContentMarketData = ${scrapeFc2ContentMarketData.toString()};`
+      content: `window.scrapeFc2ContentMarketData = ${scrapeFc2ContentMarketData.toString()};`,
     });
 
     // 実際のFc2ContentMarketスクレイピング関数をページ内で実行
@@ -378,28 +468,35 @@ test.describe('Fc2ContentMarket Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('fc2.com');
+    expect(scrapingResult.url).toContain("fc2.com");
 
     console.log(`✓ Fc2ContentMarket Title: ${scrapingResult.title}`);
-    console.log(`✓ Fc2ContentMarket Director: ${scrapingResult.director || 'Not found'}`);
-    console.log(`✓ Fc2ContentMarket ID: ${scrapingResult.id || 'Not found'}`);
-    console.log(`✓ Fc2ContentMarket Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ Fc2ContentMarket Director: ${scrapingResult.director || "Not found"}`,
+    );
+    console.log(`✓ Fc2ContentMarket ID: ${scrapingResult.id || "Not found"}`);
+    console.log(
+      `✓ Fc2ContentMarket Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // Surugaya scraping logic test
-test.describe('Surugaya Scraping Logic', () => {
-  const siteConfig = staticSites.find(site => site.service === 'Surugaya');
+test.describe("Surugaya Scraping Logic", () => {
+  const siteConfig = staticSites.find((site) => site.service === "Surugaya");
 
-  test('should successfully run Surugaya scraping logic', async ({ page, browserName }) => {
+  test("should successfully run Surugaya scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeSurugayaData = ${scrapeSurugayaData.toString()};`
+      content: `window.scrapeSurugayaData = ${scrapeSurugayaData.toString()};`,
     });
 
     // 実際のSurugayaスクレイピング関数をページ内で実行
@@ -411,29 +508,41 @@ test.describe('Surugaya Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('suruga-ya.jp');
+    expect(scrapingResult.url).toContain("suruga-ya.jp");
 
     console.log(`✓ Surugaya Title: ${scrapingResult.title}`);
-    console.log(`✓ Surugaya Authors: ${scrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ Surugaya Publisher: ${scrapingResult.publisher || 'Not found'}`);
-    console.log(`✓ Surugaya Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ Surugaya Authors: ${scrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ Surugaya Publisher: ${scrapingResult.publisher || "Not found"}`,
+    );
+    console.log(
+      `✓ Surugaya Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // Toranoana scraping logic test
-test.describe('Toranoana Scraping Logic', () => {
-  const siteConfig = staticSites.find(site => site.service === 'Toranoana');
+test.describe("Toranoana Scraping Logic", () => {
+  const siteConfig = staticSites.find((site) => site.service === "Toranoana");
 
-  test('should successfully run Toranoana scraping logic', async ({ page, browserName }) => {
+  test("should successfully run Toranoana scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
-    await page.waitForLoadState('load');
+    await page.waitForLoadState("load");
 
     // CSP問題を回避するため、関数を直接evaluateで実行
     const scrapingResult = await page.evaluate((scrapeToranoanaFunc) => {
       // スクレイピング関数をページ内で直接実行
-      const func = new Function('document', `return (${scrapeToranoanaFunc})(document);`);
+      const func = new Function(
+        "document",
+        `return (${scrapeToranoanaFunc})(document);`,
+      );
       return func(document);
     }, scrapeToranoanaData.toString());
 
@@ -441,22 +550,35 @@ test.describe('Toranoana Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('toranoana.jp');
+    expect(scrapingResult.url).toContain("toranoana.jp");
 
     console.log(`✓ Toranoana Title: ${scrapingResult.title}`);
-    console.log(`✓ Toranoana Authors: ${scrapingResult.authors.join(', ') || 'Not found'}`);
-    console.log(`✓ Toranoana Circle: ${scrapingResult.circleName || 'Not found'}`);
-    console.log(`✓ Toranoana Genre: ${scrapingResult.genre.join(', ') || 'Not found'}`);
-    console.log(`✓ Toranoana Event: ${scrapingResult.eventName || 'Not found'}`);
-    console.log(`✓ Toranoana Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ Toranoana Authors: ${scrapingResult.authors.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ Toranoana Circle: ${scrapingResult.circleName || "Not found"}`,
+    );
+    console.log(
+      `✓ Toranoana Genre: ${scrapingResult.genre.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ Toranoana Event: ${scrapingResult.eventName || "Not found"}`,
+    );
+    console.log(
+      `✓ Toranoana Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });
 
 // FANZA Anime scraping logic test
-test.describe('FANZA Anime Scraping Logic', () => {
-  const siteConfig = spaSites.find(site => site.service === 'FANZA Anime');
+test.describe("FANZA Anime Scraping Logic", () => {
+  const siteConfig = spaSites.find((site) => site.service === "FANZA Anime");
 
-  test('should successfully run FANZA Anime scraping logic', async ({ page, browserName }) => {
+  test("should successfully run FANZA Anime scraping logic", async ({
+    page,
+    browserName,
+  }) => {
     if (!siteConfig) return;
 
     await page.goto(siteConfig.url);
@@ -469,7 +591,7 @@ test.describe('FANZA Anime Scraping Logic', () => {
 
     // 関数をページに注入
     await page.addScriptTag({
-      content: `window.scrapeFanzaAnimeData = ${scrapeFanzaAnimeData.toString()};`
+      content: `window.scrapeFanzaAnimeData = ${scrapeFanzaAnimeData.toString()};`,
     });
 
     // 実際のFANZA Animeスクレイピング関数をページ内で実行
@@ -481,14 +603,22 @@ test.describe('FANZA Anime Scraping Logic', () => {
     expect(scrapingResult).toBeTruthy();
     expect(scrapingResult.title).toBeTruthy();
     expect(scrapingResult.title.length).toBeGreaterThan(0);
-    expect(scrapingResult.url).toContain('dmm.co.jp');
+    expect(scrapingResult.url).toContain("dmm.co.jp");
 
     console.log(`✓ FANZA Anime Title: ${scrapingResult.title}`);
-    console.log(`✓ FANZA Anime Actress: ${scrapingResult.actress.join(', ') || 'Not found'}`);
-    console.log(`✓ FANZA Anime Director: ${scrapingResult.director || 'Not found'}`);
-    console.log(`✓ FANZA Anime Label: ${scrapingResult.label || 'Not found'}`);
-    console.log(`✓ FANZA Anime ID: ${scrapingResult.id || 'Not found'}`);
-    console.log(`✓ FANZA Anime Manufacturer Product Number: ${scrapingResult.manufacturerProductNumber || 'Not found'}`);
-    console.log(`✓ FANZA Anime Published Date: ${scrapingResult.publishedAt || 'Not found'}`);
+    console.log(
+      `✓ FANZA Anime Actress: ${scrapingResult.actress.join(", ") || "Not found"}`,
+    );
+    console.log(
+      `✓ FANZA Anime Director: ${scrapingResult.director || "Not found"}`,
+    );
+    console.log(`✓ FANZA Anime Label: ${scrapingResult.label || "Not found"}`);
+    console.log(`✓ FANZA Anime ID: ${scrapingResult.id || "Not found"}`);
+    console.log(
+      `✓ FANZA Anime Manufacturer Product Number: ${scrapingResult.manufacturerProductNumber || "Not found"}`,
+    );
+    console.log(
+      `✓ FANZA Anime Published Date: ${scrapingResult.publishedAt || "Not found"}`,
+    );
   });
 });

--- a/src/__tests__/large/monitoring/spa-sites.test.ts
+++ b/src/__tests__/large/monitoring/spa-sites.test.ts
@@ -1,141 +1,191 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 import {
   spaSites,
   performHealthCheck,
   handleAgeVerification,
   waitForSPAContent,
   insertionTargets,
-  isEnvironmentalIpBlock
-} from './shared';
+  isEnvironmentalIpBlock,
+} from "./shared";
 
-spaSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox, isStatic, requiresJapanIP, allowIpBlock }) => {
-  const tag = requiresJapanIP ? '@japan' : '@global';
-  test.describe(`${tag} Site Monitoring - ${service} (SPA)`, () => {
+spaSites.forEach(
+  ({
+    service,
+    url,
+    selectors,
+    hasAgeVerification,
+    skipFirefox,
+    isStatic,
+    requiresJapanIP,
+    allowIpBlock,
+  }) => {
+    const tag = requiresJapanIP ? "@japan" : "@global";
+    test.describe(`${tag} Site Monitoring - ${service} (SPA)`, () => {
+      test("should have all required selectors in Chromium", async ({
+        page,
+        browserName,
+      }) => {
+        test.skip(
+          browserName !== "chromium",
+          "This test only runs on Chromium",
+        );
 
-    test('should have all required selectors in Chromium', async ({ page, browserName }) => {
-      test.skip(browserName !== 'chromium', 'This test only runs on Chromium');
-
-      // ヘルスチェック実行
-      console.log(`🏥 Health check for ${service}...`);
-      const healthCheck = await performHealthCheck(page, url);
-      console.log(`🏥 Health check result: status=${healthCheck.httpStatus}, accessible=${healthCheck.accessible}`);
-
-      // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は構造検証不能なのでskip
-      // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
-      if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
-        test.skip(true, `${service}: HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`);
-      }
-
-      if (!healthCheck.accessible) {
-        throw new Error(`❌ [NETWORK_ERROR] ${service} is not accessible: HTTP ${healthCheck.httpStatus} - ${healthCheck.error || 'Unknown error'}`);
-      }
-
-      await page.goto(url);
-
-      if (hasAgeVerification) {
-        await handleAgeVerification(page);
-      }
-
-      // SPA sites need special waiting
-      await waitForSPAContent(page, selectors);
-
-      // 各セレクタの存在確認
-      for (const selector of selectors) {
-        try {
-          const element = page.locator(selector);
-          const count = await element.count();
-          expect(count).toBeGreaterThan(0);
-        } catch (error) {
-          throw new Error(`❌ [STRUCTURE_ERROR] ${service} - Selector not found: ${selector}`);
-        }
-      }
-    });
-
-    test('should have all required selectors in Firefox', async ({ page, browserName }) => {
-      test.skip(browserName !== 'firefox' || skipFirefox, 'This test only runs on Firefox');
-
-      // ヘルスチェック実行
-      console.log(`🏥 Health check for ${service} (Firefox)...`);
-      const healthCheck = await performHealthCheck(page, url);
-      console.log(`🏥 Health check result: status=${healthCheck.httpStatus}, accessible=${healthCheck.accessible}`);
-
-      // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は構造検証不能なのでskip
-      // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
-      if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
-        test.skip(true, `${service} (Firefox): HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`);
-      }
-
-      if (!healthCheck.accessible) {
-        throw new Error(`❌ [NETWORK_ERROR] ${service} (Firefox) is not accessible: HTTP ${healthCheck.httpStatus} - ${healthCheck.error || 'Unknown error'}`);
-      }
-
-      await page.goto(url);
-
-      if (hasAgeVerification) {
-        await handleAgeVerification(page);
-      }
-
-      // SPA sites need special waiting
-      await waitForSPAContent(page, selectors);
-
-      // 各セレクタの存在確認
-      for (const selector of selectors) {
-        try {
-          const element = page.locator(selector);
-          const count = await element.count();
-          expect(count).toBeGreaterThan(0);
-        } catch (error) {
-          throw new Error(`❌ [STRUCTURE_ERROR] ${service} (Firefox) - Selector not found: ${selector}`);
-        }
-      }
-    });
-
-    // ContentScript integration tests - DOM insertion verification
-    test('should correctly insert extension bar in appropriate location', async ({ page, browserName }) => {
-      // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は挿入位置検証不能なのでskip
-      // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
-      // allowIpBlockのサイトのみ追加のヘルスチェックを行い、それ以外は余計なHTTP往復を避ける
-      if (allowIpBlock) {
+        // ヘルスチェック実行
+        console.log(`🏥 Health check for ${service}...`);
         const healthCheck = await performHealthCheck(page, url);
+        console.log(
+          `🏥 Health check result: status=${healthCheck.httpStatus}, accessible=${healthCheck.accessible}`,
+        );
+
+        // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は構造検証不能なのでskip
+        // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
         if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
-          test.skip(true, `${service}: HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`);
+          test.skip(
+            true,
+            `${service}: HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`,
+          );
         }
-      }
 
-      await page.goto(url);
+        if (!healthCheck.accessible) {
+          throw new Error(
+            `❌ [NETWORK_ERROR] ${service} is not accessible: HTTP ${healthCheck.httpStatus} - ${healthCheck.error || "Unknown error"}`,
+          );
+        }
 
-      if (hasAgeVerification) {
-        await handleAgeVerification(page);
-      }
+        await page.goto(url);
 
-      // SPA sites need special waiting
-      await waitForSPAContent(page, selectors);
+        if (hasAgeVerification) {
+          await handleAgeVerification(page);
+        }
 
-      // Check that the insertion target element exists (where ContentScript would insert the bar)
-      const targetSelector = insertionTargets[service];
-      if (targetSelector) {
-        // Try each selector (comma-separated) until one is found
-        const selectors = targetSelector.split(', ');
-        let found = false;
+        // SPA sites need special waiting
+        await waitForSPAContent(page, selectors);
 
+        // 各セレクタの存在確認
         for (const selector of selectors) {
           try {
-            const element = page.locator(selector.trim()).first();
+            const element = page.locator(selector);
             const count = await element.count();
-            if (count > 0) {
-              console.log(`✓ Found insertion target for ${service}: ${selector.trim()}`);
-              found = true;
-              break;
-            }
+            expect(count).toBeGreaterThan(0);
           } catch (error) {
-            // Continue to next selector
+            throw new Error(
+              `❌ [STRUCTURE_ERROR] ${service} - Selector not found: ${selector}`,
+            );
+          }
+        }
+      });
+
+      test("should have all required selectors in Firefox", async ({
+        page,
+        browserName,
+      }) => {
+        test.skip(
+          browserName !== "firefox" || skipFirefox,
+          "This test only runs on Firefox",
+        );
+
+        // ヘルスチェック実行
+        console.log(`🏥 Health check for ${service} (Firefox)...`);
+        const healthCheck = await performHealthCheck(page, url);
+        console.log(
+          `🏥 Health check result: status=${healthCheck.httpStatus}, accessible=${healthCheck.accessible}`,
+        );
+
+        // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は構造検証不能なのでskip
+        // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
+        if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
+          test.skip(
+            true,
+            `${service} (Firefox): HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`,
+          );
+        }
+
+        if (!healthCheck.accessible) {
+          throw new Error(
+            `❌ [NETWORK_ERROR] ${service} (Firefox) is not accessible: HTTP ${healthCheck.httpStatus} - ${healthCheck.error || "Unknown error"}`,
+          );
+        }
+
+        await page.goto(url);
+
+        if (hasAgeVerification) {
+          await handleAgeVerification(page);
+        }
+
+        // SPA sites need special waiting
+        await waitForSPAContent(page, selectors);
+
+        // 各セレクタの存在確認
+        for (const selector of selectors) {
+          try {
+            const element = page.locator(selector);
+            const count = await element.count();
+            expect(count).toBeGreaterThan(0);
+          } catch (error) {
+            throw new Error(
+              `❌ [STRUCTURE_ERROR] ${service} (Firefox) - Selector not found: ${selector}`,
+            );
+          }
+        }
+      });
+
+      // ContentScript integration tests - DOM insertion verification
+      test("should correctly insert extension bar in appropriate location", async ({
+        page,
+        browserName,
+      }) => {
+        // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は挿入位置検証不能なのでskip
+        // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
+        // allowIpBlockのサイトのみ追加のヘルスチェックを行い、それ以外は余計なHTTP往復を避ける
+        if (allowIpBlock) {
+          const healthCheck = await performHealthCheck(page, url);
+          if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
+            test.skip(
+              true,
+              `${service}: HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`,
+            );
           }
         }
 
-        if (!found) {
-          throw new Error(`❌ [INTEGRATION_ERROR] ${service} - No suitable insertion target found among: ${targetSelector}`);
+        await page.goto(url);
+
+        if (hasAgeVerification) {
+          await handleAgeVerification(page);
         }
-      }
+
+        // SPA sites need special waiting
+        await waitForSPAContent(page, selectors);
+
+        // Check that the insertion target element exists (where ContentScript would insert the bar)
+        const targetSelector = insertionTargets[service];
+        if (targetSelector) {
+          // Try each selector (comma-separated) until one is found
+          const selectors = targetSelector.split(", ");
+          let found = false;
+
+          for (const selector of selectors) {
+            try {
+              const element = page.locator(selector.trim()).first();
+              const count = await element.count();
+              if (count > 0) {
+                console.log(
+                  `✓ Found insertion target for ${service}: ${selector.trim()}`,
+                );
+                found = true;
+                break;
+              }
+            } catch (error) {
+              // Continue to next selector
+            }
+          }
+
+          if (!found) {
+            throw new Error(
+              `❌ [INTEGRATION_ERROR] ${service} - No suitable insertion target found among: ${targetSelector}`,
+            );
+          }
+        }
+      });
     });
-  });
-});
+  },
+);

--- a/src/__tests__/large/monitoring/static-sites.test.ts
+++ b/src/__tests__/large/monitoring/static-sites.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 import {
   staticSites,
   performHealthCheck,
@@ -6,155 +6,214 @@ import {
   waitForSPAContent,
   waitForStaticContent,
   insertionTargets,
-  isEnvironmentalIpBlock
-} from './shared';
+  isEnvironmentalIpBlock,
+} from "./shared";
 
-staticSites.forEach(({ service, url, selectors, hasAgeVerification, skipFirefox, isStatic, requiresJapanIP, allowIpBlock }) => {
-  const tag = requiresJapanIP ? '@japan' : '@global';
-  test.describe(`${tag} Site Monitoring - ${service} (Static)`, () => {
+staticSites.forEach(
+  ({
+    service,
+    url,
+    selectors,
+    hasAgeVerification,
+    skipFirefox,
+    isStatic,
+    requiresJapanIP,
+    allowIpBlock,
+  }) => {
+    const tag = requiresJapanIP ? "@japan" : "@global";
+    test.describe(`${tag} Site Monitoring - ${service} (Static)`, () => {
+      test("should have all required selectors in Chromium", async ({
+        page,
+        browserName,
+      }) => {
+        test.skip(
+          browserName !== "chromium",
+          "This test only runs on Chromium",
+        );
 
-    test('should have all required selectors in Chromium', async ({ page, browserName }) => {
-      test.skip(browserName !== 'chromium', 'This test only runs on Chromium');
-
-      // ヘルスチェック実行
-      console.log(`🏥 Health check for ${service}...`);
-      const healthCheck = await performHealthCheck(page, url);
-      console.log(`🏥 Health check result: status=${healthCheck.httpStatus}, accessible=${healthCheck.accessible}`);
-
-      // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は構造検証不能なのでskip
-      // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
-      if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
-        test.skip(true, `${service}: HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`);
-      }
-
-      if (!healthCheck.accessible) {
-        throw new Error(`❌ [NETWORK_ERROR] ${service} is not accessible: HTTP ${healthCheck.httpStatus} - ${healthCheck.error || 'Unknown error'}`);
-      }
-
-      await page.goto(url);
-
-      if (hasAgeVerification) {
-        await handleAgeVerification(page);
-      }
-
-      // Static sites can proceed immediately after load
-      await page.waitForLoadState('load');
-
-      // 動的DOM生成を考慮した待機 (一部のサイトはページロード後もJSで要素を生成する)
-      await waitForStaticContent(page, selectors);
-
-      // 各セレクタの存在確認
-      for (const selector of selectors) {
-        try {
-          const element = page.locator(selector);
-          const count = await element.count();
-          expect(count).toBeGreaterThan(0);
-        } catch (error) {
-          throw new Error(`❌ [STRUCTURE_ERROR] ${service} - Selector not found: ${selector}`);
-        }
-      }
-    });
-
-    test('should have all required selectors in Firefox', async ({ page, browserName }) => {
-      test.skip(browserName !== 'firefox' || skipFirefox, 'This test only runs on Firefox');
-
-      // ヘルスチェック実行
-      console.log(`🏥 Health check for ${service} (Firefox)...`);
-      const healthCheck = await performHealthCheck(page, url);
-      console.log(`🏥 Health check result: status=${healthCheck.httpStatus}, accessible=${healthCheck.accessible}`);
-
-      // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は構造検証不能なのでskip
-      // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
-      if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
-        test.skip(true, `${service} (Firefox): HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`);
-      }
-
-      if (!healthCheck.accessible) {
-        throw new Error(`❌ [NETWORK_ERROR] ${service} (Firefox) is not accessible: HTTP ${healthCheck.httpStatus} - ${healthCheck.error || 'Unknown error'}`);
-      }
-
-      await page.goto(url);
-
-      if (hasAgeVerification) {
-        await handleAgeVerification(page);
-      }
-
-      // Static sites can proceed immediately after load
-      await page.waitForLoadState('load');
-
-      // 動的DOM生成を考慮した待機 (一部のサイトはページロード後もJSで要素を生成する)
-      await waitForStaticContent(page, selectors);
-
-      // 各セレクタの存在確認
-      for (const selector of selectors) {
-        try {
-          const element = page.locator(selector);
-          const count = await element.count();
-          expect(count).toBeGreaterThan(0);
-        } catch (error) {
-          throw new Error(`❌ [STRUCTURE_ERROR] ${service} (Firefox) - Selector not found: ${selector}`);
-        }
-      }
-    });
-
-    // ContentScript integration tests - DOM insertion verification
-    test('should correctly insert extension bar in appropriate location', async ({ page, browserName }) => {
-      // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は挿入位置検証不能なのでskip
-      // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
-      // allowIpBlockのサイトのみ追加のヘルスチェックを行い、それ以外は余計なHTTP往復を避ける
-      if (allowIpBlock) {
+        // ヘルスチェック実行
+        console.log(`🏥 Health check for ${service}...`);
         const healthCheck = await performHealthCheck(page, url);
+        console.log(
+          `🏥 Health check result: status=${healthCheck.httpStatus}, accessible=${healthCheck.accessible}`,
+        );
+
+        // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は構造検証不能なのでskip
+        // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
         if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
-          test.skip(true, `${service}: HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`);
+          test.skip(
+            true,
+            `${service}: HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`,
+          );
         }
-      }
 
-      await page.goto(url);
+        if (!healthCheck.accessible) {
+          throw new Error(
+            `❌ [NETWORK_ERROR] ${service} is not accessible: HTTP ${healthCheck.httpStatus} - ${healthCheck.error || "Unknown error"}`,
+          );
+        }
 
-      if (hasAgeVerification) {
-        await handleAgeVerification(page);
-      }
+        await page.goto(url);
 
-      // Static sites - wait for load
-      await page.waitForLoadState('load');
+        if (hasAgeVerification) {
+          await handleAgeVerification(page);
+        }
 
-      // Check that the insertion target element exists (where ContentScript would insert the bar)
-      const targetSelector = insertionTargets[service];
-      if (targetSelector) {
-        // Try each selector (comma-separated) until one is found
-        const selectors = targetSelector.split(', ');
-        let found = false;
+        // Static sites can proceed immediately after load
+        await page.waitForLoadState("load");
 
+        // 動的DOM生成を考慮した待機 (一部のサイトはページロード後もJSで要素を生成する)
+        await waitForStaticContent(page, selectors);
+
+        // 各セレクタの存在確認
         for (const selector of selectors) {
           try {
-            const trimmedSelector = selector.trim();
-
-            // 高速チェック - 既に存在するか確認
-            const quickCheck = await page.locator(trimmedSelector).first().count().catch(() => 0);
-            if (quickCheck > 0) {
-              console.log(`✓ Found insertion target for ${service}: ${trimmedSelector}`);
-              found = true;
-              break;
-            }
-
-            // 動的に生成される可能性のある要素を待機 (例: Amazon #navbar)
-            await page.waitForSelector(trimmedSelector, { timeout: 10000, state: 'attached' });
-            const element = page.locator(trimmedSelector).first();
+            const element = page.locator(selector);
             const count = await element.count();
-            if (count > 0) {
-              console.log(`✓ Found insertion target for ${service}: ${trimmedSelector}`);
-              found = true;
-              break;
-            }
+            expect(count).toBeGreaterThan(0);
           } catch (error) {
-            // Continue to next selector
+            throw new Error(
+              `❌ [STRUCTURE_ERROR] ${service} - Selector not found: ${selector}`,
+            );
+          }
+        }
+      });
+
+      test("should have all required selectors in Firefox", async ({
+        page,
+        browserName,
+      }) => {
+        test.skip(
+          browserName !== "firefox" || skipFirefox,
+          "This test only runs on Firefox",
+        );
+
+        // ヘルスチェック実行
+        console.log(`🏥 Health check for ${service} (Firefox)...`);
+        const healthCheck = await performHealthCheck(page, url);
+        console.log(
+          `🏥 Health check result: status=${healthCheck.httpStatus}, accessible=${healthCheck.accessible}`,
+        );
+
+        // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は構造検証不能なのでskip
+        // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
+        if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
+          test.skip(
+            true,
+            `${service} (Firefox): HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`,
+          );
+        }
+
+        if (!healthCheck.accessible) {
+          throw new Error(
+            `❌ [NETWORK_ERROR] ${service} (Firefox) is not accessible: HTTP ${healthCheck.httpStatus} - ${healthCheck.error || "Unknown error"}`,
+          );
+        }
+
+        await page.goto(url);
+
+        if (hasAgeVerification) {
+          await handleAgeVerification(page);
+        }
+
+        // Static sites can proceed immediately after load
+        await page.waitForLoadState("load");
+
+        // 動的DOM生成を考慮した待機 (一部のサイトはページロード後もJSで要素を生成する)
+        await waitForStaticContent(page, selectors);
+
+        // 各セレクタの存在確認
+        for (const selector of selectors) {
+          try {
+            const element = page.locator(selector);
+            const count = await element.count();
+            expect(count).toBeGreaterThan(0);
+          } catch (error) {
+            throw new Error(
+              `❌ [STRUCTURE_ERROR] ${service} (Firefox) - Selector not found: ${selector}`,
+            );
+          }
+        }
+      });
+
+      // ContentScript integration tests - DOM insertion verification
+      test("should correctly insert extension bar in appropriate location", async ({
+        page,
+        browserName,
+      }) => {
+        // CIのVPNデータセンターIPがCloudflareに403でブロックされた場合は挿入位置検証不能なのでskip
+        // (環境要因。詳細: docs/monitoring-ip-block-limitation.md)
+        // allowIpBlockのサイトのみ追加のヘルスチェックを行い、それ以外は余計なHTTP往復を避ける
+        if (allowIpBlock) {
+          const healthCheck = await performHealthCheck(page, url);
+          if (isEnvironmentalIpBlock(healthCheck, allowIpBlock)) {
+            test.skip(
+              true,
+              `${service}: HTTP 403 — Cloudflare datacenter-IP block (environmental, not a structure change). See docs/monitoring-ip-block-limitation.md`,
+            );
           }
         }
 
-        if (!found) {
-          throw new Error(`❌ [INTEGRATION_ERROR] ${service} - No suitable insertion target found among: ${targetSelector}`);
+        await page.goto(url);
+
+        if (hasAgeVerification) {
+          await handleAgeVerification(page);
         }
-      }
+
+        // Static sites - wait for load
+        await page.waitForLoadState("load");
+
+        // Check that the insertion target element exists (where ContentScript would insert the bar)
+        const targetSelector = insertionTargets[service];
+        if (targetSelector) {
+          // Try each selector (comma-separated) until one is found
+          const selectors = targetSelector.split(", ");
+          let found = false;
+
+          for (const selector of selectors) {
+            try {
+              const trimmedSelector = selector.trim();
+
+              // 高速チェック - 既に存在するか確認
+              const quickCheck = await page
+                .locator(trimmedSelector)
+                .first()
+                .count()
+                .catch(() => 0);
+              if (quickCheck > 0) {
+                console.log(
+                  `✓ Found insertion target for ${service}: ${trimmedSelector}`,
+                );
+                found = true;
+                break;
+              }
+
+              // 動的に生成される可能性のある要素を待機 (例: Amazon #navbar)
+              await page.waitForSelector(trimmedSelector, {
+                timeout: 10000,
+                state: "attached",
+              });
+              const element = page.locator(trimmedSelector).first();
+              const count = await element.count();
+              if (count > 0) {
+                console.log(
+                  `✓ Found insertion target for ${service}: ${trimmedSelector}`,
+                );
+                found = true;
+                break;
+              }
+            } catch (error) {
+              // Continue to next selector
+            }
+          }
+
+          if (!found) {
+            throw new Error(
+              `❌ [INTEGRATION_ERROR] ${service} - No suitable insertion target found among: ${targetSelector}`,
+            );
+          }
+        }
+      });
     });
-  });
-});
+  },
+);

--- a/src/__tests__/small/contentScript/base-content-script-message.test.ts
+++ b/src/__tests__/small/contentScript/base-content-script-message.test.ts
@@ -32,7 +32,6 @@ class TestContentScript extends BaseContentScript {
 }
 
 class MountTestContentScript extends BaseContentScript {
-
   protected scrape(): Product | null {
     return null;
   }
@@ -251,9 +250,7 @@ describe("動的描画サイト (waitForDynamicContent)", () => {
   }
 
   test("即時scrape失敗後、DOM変化でscrapeが成功したら検索する", async () => {
-    const { document } = parseHTML(
-      "<!DOCTYPE html><html><body></body></html>",
-    );
+    const { document } = parseHTML("<!DOCTYPE html><html><body></body></html>");
     setGlobalDocument(document as unknown as Document);
 
     new DynamicScript(document as unknown as Document).execute();
@@ -275,9 +272,7 @@ describe("動的描画サイト (waitForDynamicContent)", () => {
   });
 
   test("DOMが変化してもscrapeが成功しなければ検索しない", async () => {
-    const { document } = parseHTML(
-      "<!DOCTYPE html><html><body></body></html>",
-    );
+    const { document } = parseHTML("<!DOCTYPE html><html><body></body></html>");
     setGlobalDocument(document as unknown as Document);
 
     new DynamicScript(document as unknown as Document).execute();

--- a/src/__tests__/small/contentScript/wait-for-scrape.test.ts
+++ b/src/__tests__/small/contentScript/wait-for-scrape.test.ts
@@ -8,9 +8,7 @@ import {
 // jsdom は parse5 の ESM/CJS 境界で jest が読めないため、
 // scraper-fixtures テストと同様に linkedom で DOM を組み立てる。
 function makeDom(): Document {
-  const { document } = parseHTML(
-    "<!DOCTYPE html><html><body></body></html>",
-  );
+  const { document } = parseHTML("<!DOCTYPE html><html><body></body></html>");
   return document as unknown as Document;
 }
 

--- a/src/__tests__/small/popup/normalizeProjectName.test.ts
+++ b/src/__tests__/small/popup/normalizeProjectName.test.ts
@@ -10,19 +10,27 @@ test("プロジェクト名_末尾スラッシュ削除", () => {
 });
 
 test("完全なURL_httpsプロトコル付き", () => {
-  expect(normalizeProjectName("https://scrapbox.io/project-name")).toBe("project-name");
+  expect(normalizeProjectName("https://scrapbox.io/project-name")).toBe(
+    "project-name",
+  );
 });
 
 test("完全なURL_httpsプロトコル付き_末尾スラッシュあり", () => {
-  expect(normalizeProjectName("https://scrapbox.io/project-name/")).toBe("project-name");
+  expect(normalizeProjectName("https://scrapbox.io/project-name/")).toBe(
+    "project-name",
+  );
 });
 
 test("URL_ページパス含む場合はプロジェクト名のみ抽出", () => {
-  expect(normalizeProjectName("https://scrapbox.io/project-name/some-page")).toBe("project-name");
+  expect(
+    normalizeProjectName("https://scrapbox.io/project-name/some-page"),
+  ).toBe("project-name");
 });
 
 test("URL_クエリパラメータ含む", () => {
-  expect(normalizeProjectName("https://scrapbox.io/project-name?foo=bar")).toBe("project-name");
+  expect(normalizeProjectName("https://scrapbox.io/project-name?foo=bar")).toBe(
+    "project-name",
+  );
 });
 
 test("前後の空白削除", () => {

--- a/src/popup/normalizeProjectName.ts
+++ b/src/popup/normalizeProjectName.ts
@@ -12,13 +12,15 @@ export function normalizeProjectName(input: string): string {
 
   // Extract project name from full URL if provided
   // Supports: https://, http://, protocol-less, query params, hash fragments
-  const urlMatch = projectName.match(/(?:https?:\/\/)?scrapbox\.io\/([^\/?#]+)/);
+  const urlMatch = projectName.match(
+    /(?:https?:\/\/)?scrapbox\.io\/([^\/?#]+)/,
+  );
   if (urlMatch) {
     projectName = urlMatch[1];
   }
 
   // Remove trailing slash(es)
-  projectName = projectName.replace(/\/+$/, '');
+  projectName = projectName.replace(/\/+$/, "");
 
   return projectName;
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   manifest: ({ browser }) => ({
     name: "Uni",
     description: "Building your library on the Cosense",
-    version: "2.1.4",
+    version: "2.1.5",
     icons: {
       16: "icon16.png",
       48: "icon48.png",


### PR DESCRIPTION
## Summary

- bump the extension version from 2.1.4 to 2.1.5
- align existing TypeScript formatting with the publish workflow check
- verify Chrome and Firefox release packages report version 2.1.5

## Verification

- `npx prettier --check **/*.{ts,tsx,scss}`
- `npm test` (17 suites, 117 tests)
- `npm run package:all`
- checked generated Chrome and Firefox manifests are both version 2.1.5

## Release

After this PR is merged, publish a GitHub Release for `2.1.5`. The `Publish Chrome Extension` and `Publish Firefox Extension` workflows are triggered by the `release.published` event.
