### PR TITLE
release: migrate Chrome publishing to API v2

### DIFF
--- a/.github/workflows/publish-chrome.yml
+++ b/.github/workflows/publish-chrome.yml
@@ -4,17 +4,32 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Validate access without publishing, or publish a new version
+        required: true
+        default: validate
+        type: choice
+        options:
+          - validate
+          - publish
 
 jobs:
   publish-chrome:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      CHROME_EXTENSION_ID: jdihchpmnchcjigdmecmjieeanhcfbpm
+      CHROME_WEB_STORE_SCOPE: https://www.googleapis.com/auth/chromewebstore
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node with mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
 
       - name: Install dependencies
         run: npm ci
@@ -27,21 +42,156 @@ jobs:
 
       - name: Load secrets from 1Password
         id: load_secrets
-        uses: 1password/load-secrets-action@v3
+        uses: 1Password/load-secrets-action@dafbe7cb03502b260e2b2893c753c352eee545bf # v3
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          CHROME_CLIENT_ID: op://Web/uni/CHROME_CLIENT_ID
-          CHROME_CLIENT_SECRET: op://Web/uni/CHROME_CLIENT_SECRET
-          CHROME_REFRESH_TOKEN: op://Web/uni/CHROME_REFRESH_TOKEN
+          CHROME_PUBLISHER_ID: op://Web/uni/CHROME_PUBLISHER_ID
+          CHROME_SERVICE_ACCOUNT_JSON: op://Web/uni/CHROME_SERVICE_ACCOUNT_JSON
+
+      - name: Authenticate to Google Cloud
+        id: google_auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          credentials_json: ${{ steps.load_secrets.outputs.CHROME_SERVICE_ACCOUNT_JSON }}
+          token_format: access_token
+          access_token_scopes: ${{ env.CHROME_WEB_STORE_SCOPE }}
+
+      - name: Preflight Chrome Web Store access
+        env:
+          ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          CHROME_PUBLISHER_ID: ${{ steps.load_secrets.outputs.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$ACCESS_TOKEN" || -z "$CHROME_PUBLISHER_ID" ]]; then
+            echo "Chrome Web Store authentication is not configured." >&2
+            exit 1
+          fi
+
+          status_url="https://chromewebstore.googleapis.com/v2/publishers/${CHROME_PUBLISHER_ID}/items/${CHROME_EXTENSION_ID}:fetchStatus"
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+            --header "Authorization: Bearer ${ACCESS_TOKEN}" \
+            "$status_url")"
+
+          if [[ "$http_status" != "200" ]]; then
+            echo "Chrome Web Store preflight failed (HTTP ${http_status}). Check the publisher ID and Developer Dashboard service-account link." >&2
+            jq -r '.error.message // "No API error message returned"' "$response_file" >&2
+            exit 1
+          fi
+
+          echo "Chrome Web Store authentication and item access verified."
 
       - name: Build and package Chrome extension
+        if: github.event_name == 'release' || inputs.mode == 'publish'
         run: npm run package:chrome
 
-      - name: Publish to Chrome Web Store
-        uses: mobilefirstllc/cws-publish@latest
-        with:
-          extension_id: jdihchpmnchcjigdmecmjieeanhcfbpm
-          client_id: ${{ steps.load_secrets.outputs.CHROME_CLIENT_ID }}
-          client_secret: ${{ steps.load_secrets.outputs.CHROME_CLIENT_SECRET }}
-          refresh_token: ${{ steps.load_secrets.outputs.CHROME_REFRESH_TOKEN }}
-          zip_file: dist/uni-chrome.zip
+      - name: Upload to Chrome Web Store
+        if: github.event_name == 'release' || inputs.mode == 'publish'
+        env:
+          ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          CHROME_PUBLISHER_ID: ${{ steps.load_secrets.outputs.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+
+          upload_url="https://chromewebstore.googleapis.com/upload/v2/publishers/${CHROME_PUBLISHER_ID}/items/${CHROME_EXTENSION_ID}:upload"
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+            --request POST \
+            --header "Authorization: Bearer ${ACCESS_TOKEN}" \
+            --header "Content-Type: application/zip" \
+            --upload-file dist/uni-chrome.zip \
+            "$upload_url")"
+
+          if [[ "$http_status" -lt 200 || "$http_status" -ge 300 ]]; then
+            echo "Chrome Web Store upload failed (HTTP ${http_status})." >&2
+            jq -r '.error.message // "No API error message returned"' "$response_file" >&2
+            exit 1
+          fi
+
+          upload_state="$(jq -r '.uploadState // empty' "$response_file")"
+          if [[ "$upload_state" != "SUCCEEDED" && "$upload_state" != "IN_PROGRESS" ]]; then
+            echo "Chrome Web Store rejected the upload (state: ${upload_state:-unknown})." >&2
+            exit 1
+          fi
+
+          echo "Chrome Web Store upload accepted (state: ${upload_state})."
+
+      - name: Wait for upload processing
+        if: github.event_name == 'release' || inputs.mode == 'publish'
+        env:
+          ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          CHROME_PUBLISHER_ID: ${{ steps.load_secrets.outputs.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+
+          status_url="https://chromewebstore.googleapis.com/v2/publishers/${CHROME_PUBLISHER_ID}/items/${CHROME_EXTENSION_ID}:fetchStatus"
+          for attempt in {1..30}; do
+            response="$(curl --fail-with-body --silent --show-error \
+              --header "Authorization: Bearer ${ACCESS_TOKEN}" \
+              "$status_url")"
+            upload_state="$(jq -r '.lastAsyncUploadState // empty' <<<"$response")"
+
+            if [[ "$upload_state" == "SUCCEEDED" ]]; then
+              echo "Chrome Web Store finished processing the upload."
+              exit 0
+            fi
+            if [[ "$upload_state" != "IN_PROGRESS" ]]; then
+              echo "Chrome Web Store upload processing failed (state: ${upload_state:-unknown})." >&2
+              exit 1
+            fi
+
+            echo "Upload is still processing (attempt ${attempt}/30)."
+            sleep 10
+          done
+
+          echo "Timed out waiting for Chrome Web Store upload processing." >&2
+          exit 1
+
+      - name: Submit for review and publication
+        if: github.event_name == 'release' || inputs.mode == 'publish'
+        env:
+          ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          CHROME_PUBLISHER_ID: ${{ steps.load_secrets.outputs.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+
+          publish_url="https://chromewebstore.googleapis.com/v2/publishers/${CHROME_PUBLISHER_ID}/items/${CHROME_EXTENSION_ID}:publish"
+          response_file="$(mktemp)"
+          http_status="$(curl --silent --show-error --output "$response_file" --write-out '%{http_code}' \
+            --request POST \
+            --header "Authorization: Bearer ${ACCESS_TOKEN}" \
+            --header "Content-Type: application/json" \
+            --data '{}' \
+            "$publish_url")"
+
+          if [[ "$http_status" -lt 200 || "$http_status" -ge 300 ]]; then
+            echo "Chrome Web Store review submission failed (HTTP ${http_status})." >&2
+            jq -r '.error.message // "No API error message returned"' "$response_file" >&2
+            exit 1
+          fi
+
+          submission_state="$(jq -r '.state // empty' "$response_file")"
+          case "$submission_state" in
+            PENDING_REVIEW | STAGED | PUBLISHED | PUBLISHED_TO_TESTERS) ;;
+            *)
+              echo "Chrome Web Store returned an unsuccessful submission state: ${submission_state:-unknown}." >&2
+              exit 1
+              ;;
+          esac
+
+          echo "Chrome Web Store review submission accepted (state: ${submission_state})."
+
+      - name: Report Chrome Web Store status
+        if: github.event_name == 'release' || inputs.mode == 'publish'
+        env:
+          ACCESS_TOKEN: ${{ steps.google_auth.outputs.access_token }}
+          CHROME_PUBLISHER_ID: ${{ steps.load_secrets.outputs.CHROME_PUBLISHER_ID }}
+        run: |
+          set -euo pipefail
+
+          status_url="https://chromewebstore.googleapis.com/v2/publishers/${CHROME_PUBLISHER_ID}/items/${CHROME_EXTENSION_ID}:fetchStatus"
+          curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer ${ACCESS_TOKEN}" \
+            "$status_url" |
+            jq '{uploadState: .lastAsyncUploadState, publishedState: .publishedItemRevisionStatus.state, submittedState: .submittedItemRevisionStatus.state}'

--- a/docs/chrome-web-store-release.md
+++ b/docs/chrome-web-store-release.md
@@ -1,102 +1,50 @@
 # Chrome Web Storeリリース手順
 
-このドキュメントでは、Chrome Web Store用のOAuth認証情報を更新し、GitHub Actionsから拡張機能をアップロードする手順を説明します。
+このドキュメントでは、Chrome Web Store API v2とサービスアカウントを使い、GitHub Actionsから拡張機能をアップロードして審査へ提出する手順を説明します。
 
 ## 前提条件
 
 - Chrome Web Storeの公開者アカウントへログインできる
-- Google Cloud ConsoleでOAuthクライアントを作成できる
+- Google Cloud Consoleでサービスアカウントを作成できる
 - `Web` Vaultの`uni`アイテムを1Password CLIから参照できる
-- `gh`、`op`、`curl`、`jq`をローカルで実行できる
+- `gh`と`op`をローカルで実行できる
 
 GitHub Actionsは、次の1Password参照から認証情報を読み込みます。
 
 ```text
-op://Web/uni/CHROME_CLIENT_ID
-op://Web/uni/CHROME_CLIENT_SECRET
-op://Web/uni/CHROME_REFRESH_TOKEN
+op://Web/uni/CHROME_PUBLISHER_ID
+op://Web/uni/CHROME_SERVICE_ACCOUNT_JSON
 ```
 
-## OAuth認証情報を発行する
+## サービスアカウントを設定する
 
-### 1. OAuthクライアントを作成する
+1. Google Cloud ConsoleでChrome Web Store APIを有効にします。
+2. 専用のサービスアカウントを作成します。この時点ではGoogle Cloud IAMロールの追加は不要です。
+3. Chrome Web Store Developer Dashboardの「Account」で、サービスアカウントのメールアドレスをpublisherへ追加します。publisherに追加できるサービスアカウントは1つです。
+4. サービスアカウントのJSON鍵を作成します。
+5. Developer Dashboardからpublisher IDを確認します。
 
-Google Cloud Consoleの「APIとサービス」から「認証情報」を開き、OAuth 2.0クライアントを作成します。
-
-- アプリケーションの種類: ウェブ アプリケーション
-- 名前: `uni Chrome Web Store CI`
-- 承認済みのリダイレクトURI: `https://developers.google.com/oauthplayground`
-
-作成後、Client IDとClient Secretを控えます。
-
-### 2. Refresh tokenを発行する
-
-[OAuth 2.0 Playground](https://developers.google.com/oauthplayground/)を開き、次の操作を行います。
-
-1. 右上の歯車アイコンを開く
-2. `Use your own OAuth credentials`を有効にする
-3. 作成したClient IDとClient Secretを入力する
-4. 次のスコープを入力する
-
-    ```text
-    https://www.googleapis.com/auth/chromewebstore
-    ```
-
-5. `Authorize APIs`を実行する
-6. Chrome Web Storeの公開者アカウントで許可する
-7. `Exchange authorization code for tokens`を実行する
-8. 表示されたRefresh tokenを控える
-
-必ず対象の拡張機能を所有しているGoogleアカウントで許可してください。
+詳細はChrome公式の[サービスアカウント設定手順](https://developer.chrome.com/docs/webstore/service-accounts)を参照してください。
 
 ## 1Passwordを更新する
 
-新しいOAuthクライアントを作成した場合は、Client ID、Client Secret、Refresh tokenをまとめて更新します。
+publisher IDとJSON鍵の内容全体を、それぞれ1Passwordの`uni`アイテムへ保存します。
 
-```bash
-read -r "CLIENT_ID?Client ID: "
-read -rs "CLIENT_SECRET?Client Secret: "
-echo
-read -rs "REFRESH_TOKEN?Refresh token: "
-echo
-
-op item edit "uni" --vault "Web" \
-  "CHROME_CLIENT_ID=$CLIENT_ID" \
-  "CHROME_CLIENT_SECRET=$CLIENT_SECRET" \
-  "CHROME_REFRESH_TOKEN=$REFRESH_TOKEN"
-```
-
-## 1Passwordの値をローカルで検証する
-
-GitHub Actionsを実行する前に、1Passwordに保存した3つの値を使ってアクセストークンを取得できることを確認します。次のコマンドは秘密値を表示せず、検証結果だけを出力します。
-
-```bash
-CLIENT_ID="$(op read 'op://Web/uni/CHROME_CLIENT_ID')" \
-CLIENT_SECRET="$(op read 'op://Web/uni/CHROME_CLIENT_SECRET')" \
-REFRESH_TOKEN="$(op read 'op://Web/uni/CHROME_REFRESH_TOKEN')" \
-zsh -c '
-curl -sS https://oauth2.googleapis.com/token \
-  --data-urlencode "client_id=$CLIENT_ID" \
-  --data-urlencode "client_secret=$CLIENT_SECRET" \
-  --data-urlencode "refresh_token=$REFRESH_TOKEN" \
-  --data-urlencode "grant_type=refresh_token" |
-jq "{ok: has(\"access_token\"), error, error_description}"
-'
-```
-
-成功時は次の結果になります。
-
-```json
-{
-    "ok": true,
-    "error": null,
-    "error_description": null
-}
-```
-
-`invalid_grant`が返る場合は、Refresh tokenが失効しているか、発行時と異なるClient IDまたはClient Secretを使用しています。3つの値を同じOAuthクライアントから再発行してください。
+JSON鍵は改行を含む値のまま保存してください。CLIから更新する場合、シェル引数やログへ鍵を露出させないように`op item edit`の対話編集を使います。移行完了後、旧`CHROME_CLIENT_ID`、`CHROME_CLIENT_SECRET`、`CHROME_REFRESH_TOKEN`フィールドは削除できます。
 
 ## GitHub Actionsを実行する
+
+### 認証と権限だけを確認する
+
+GitHub Actionsの`Publish Chrome Extension`を手動実行し、`mode`で`validate`を選択します。`validate`は既定値です。
+
+このモードではサービスアカウント認証と対象拡張機能へのアクセスだけを確認します。ZIPの作成、アップロード、審査提出は実行しないため、公開済みバージョンと同じバージョンでも安全に実行できます。
+
+`Preflight Chrome Web Store access`が成功し、以降の公開ステップがskipされていることを確認してください。
+
+### 新しいバージョンを公開する
+
+通常は、バージョンを更新したGitHub Releaseをpublishすると公開処理が自動実行されます。手動で公開する必要がある場合に限り、`mode`で`publish`を明示的に選択してください。同じバージョンを再アップロードすることはできません。
 
 リリースに紐づく失敗ジョブを再実行する場合は、次のコマンドを使います。
 
@@ -105,16 +53,13 @@ gh run rerun RUN_ID --failed --repo motoso/uni
 gh run watch RUN_ID --repo motoso/uni --exit-status
 ```
 
-`Publish to Chrome Web Store`ステップが成功したことを確認します。
+次のステップが成功したことを確認します。
 
-現行の`.github/workflows/publish-chrome.yml`は、Chrome Web StoreへZIPファイルをアップロードします。Actionの実行ログでは`action: upload`として動作します。CI成功後、Chrome Web Store Developer Dashboardで審査提出と公開状態を確認してください。
+- `Preflight Chrome Web Store access`: 認証、publisher ID、拡張機能へのアクセスを検証
+- `Upload to Chrome Web Store`: API v2でZIPファイルをアップロード
+- `Submit for review and publication`: 審査へ提出し、承認後の公開を予約
+- `Report Chrome Web Store status`: 提出直後の状態をログへ出力
 
-## 後片付け
+APIの`publish`は審査通過後の公開までを要求します。CI成功は審査通過や公開完了を意味しないため、Developer Dashboardでも最終状態を確認してください。API v2の各操作はChrome公式の[API利用手順](https://developer.chrome.com/docs/webstore/using-api)を参照してください。
 
-シェル変数から認証情報を削除します。
-
-```bash
-unset CLIENT_ID CLIENT_SECRET REFRESH_TOKEN
-```
-
-Client SecretやRefresh tokenを、Issue、Pull Request、CIログへ貼り付けないでください。
+サービスアカウントのJSON鍵を、Issue、Pull Request、CIログへ貼り付けないでください。鍵が漏洩した場合はGoogle Cloud Consoleで直ちに無効化し、新しい鍵へ交換してください。

--- a/docs/chrome-web-store-release.md
+++ b/docs/chrome-web-store-release.md
@@ -18,19 +18,114 @@ op://Web/uni/CHROME_SERVICE_ACCOUNT_JSON
 
 ## サービスアカウントを設定する
 
-1. Google Cloud ConsoleでChrome Web Store APIを有効にします。
-2. 専用のサービスアカウントを作成します。この時点ではGoogle Cloud IAMロールの追加は不要です。
-3. Chrome Web Store Developer Dashboardの「Account」で、サービスアカウントのメールアドレスをpublisherへ追加します。publisherに追加できるサービスアカウントは1つです。
-4. サービスアカウントのJSON鍵を作成します。
-5. Developer Dashboardからpublisher IDを確認します。
+### 1. Google Cloudプロジェクトを選ぶ
+
+1. [Google Cloud Console](https://console.cloud.google.com/)を開きます。
+2. 画面上部のプロジェクト選択から、uniの公開に使うプロジェクトを選びます。適切なプロジェクトがない場合は、`uni-chrome-web-store`などの名前で作成します。
+
+従来のOAuthクライアントと同じプロジェクトである必要はありません。
+
+### 2. Chrome Web Store APIを有効にする
+
+1. Google Cloud Consoleで「APIとサービス」→「ライブラリ」を開きます。
+2. `Chrome Web Store API`を検索します。
+3. 対象がChrome Web Store APIであることを確認し、「有効にする」を選択します。
+
+### 3. サービスアカウントを作成する
+
+1. Google Cloud Consoleの[サービスアカウント一覧](https://console.cloud.google.com/iam-admin/serviceaccounts)を開きます。
+2. 「サービスアカウントを作成」を選択します。
+3. 次のように入力します。
+
+    ```text
+    サービスアカウント名: uni-chrome-web-store
+    説明: Publishes uni from GitHub Actions
+    ```
+
+4. 「作成して続行」を選択します。
+5. Google Cloud IAMロールは追加せず、「続行」または「完了」を選択します。
+
+作成後、次の形式のサービスアカウントメールアドレスを控えます。このメールアドレス自体は秘密情報ではありません。
+
+```text
+uni-chrome-web-store@PROJECT_ID.iam.gserviceaccount.com
+```
+
+Chrome Web Storeに対する権限はGoogle Cloud IAMではなく、次の手順でDeveloper Dashboardから付与します。
+
+### 4. Chrome Web Storeのpublisherへ登録する
+
+1. [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole/)を開き、uniを所有している公開者アカウントでログインします。
+2. 複数のpublisherに所属している場合は、uniを所有するpublisherへ切り替えます。
+3. 「Account」を開きます。
+4. サービスアカウント設定欄へ、前の手順で控えたメールアドレスを入力して保存します。
+
+publisherへ登録できるサービスアカウントは1つです。すでに別のサービスアカウントが登録されている場合は、置き換える前に他の公開処理で使われていないことを確認してください。
+
+### 5. Publisher IDを確認する
+
+Developer Dashboardの「Publisher」→「Settings」でPublisher IDを確認して控えます。Publisher IDと拡張機能IDは別の値です。
+
+uniの拡張機能IDは次の値です。
+
+```text
+jdihchpmnchcjigdmecmjieeanhcfbpm
+```
+
+### 6. JSON鍵を作成する
+
+1. Google Cloud Consoleのサービスアカウント一覧へ戻ります。
+2. 作成した`uni-chrome-web-store`を選択します。
+3. 「キー」タブを開きます。
+4. 「鍵を追加」→「新しい鍵を作成」を選択します。
+5. キーのタイプとして「JSON」を選択し、「作成」を選択します。
+
+ダウンロードされたJSONファイルは、サービスアカウントとして認証できる秘密鍵です。Gitへ追加したり、Issue、Pull Request、チャット、CIログへ内容を貼り付けたりしないでください。
 
 詳細はChrome公式の[サービスアカウント設定手順](https://developer.chrome.com/docs/webstore/service-accounts)を参照してください。
 
 ## 1Passwordを更新する
 
-publisher IDとJSON鍵の内容全体を、それぞれ1Passwordの`uni`アイテムへ保存します。
+1Passwordアプリで`Web` Vaultの`uni`アイテムを開き、次の2つのTextフィールドを追加します。
 
-JSON鍵は改行を含む値のまま保存してください。CLIから更新する場合、シェル引数やログへ鍵を露出させないように`op item edit`の対話編集を使います。移行完了後、旧`CHROME_CLIENT_ID`、`CHROME_CLIENT_SECRET`、`CHROME_REFRESH_TOKEN`フィールドは削除できます。
+| フィールド名                  | 値                                        |
+| ----------------------------- | ----------------------------------------- |
+| `CHROME_PUBLISHER_ID`         | Developer Dashboardで確認したPublisher ID |
+| `CHROME_SERVICE_ACCOUNT_JSON` | ダウンロードしたJSONファイルの内容全体    |
+
+JSON鍵は先頭の`{`から最後の`}`まで、改行を含む値のまま保存してください。シェル引数やログへ鍵を露出させないため、CLIより1Passwordアプリでの編集を推奨します。
+
+保存後、ダウンロードフォルダなどに残ったJSONファイルを安全に削除します。JSON鍵を再表示する必要がある運用は避け、漏洩した可能性がある場合はGoogle Cloud Consoleで直ちに無効化して新しい鍵へ交換してください。
+
+### 1Passwordの設定を確認する
+
+次のコマンドは秘密値を表示せず、2つの参照が存在することとJSON鍵の基本構造を確認します。
+
+```bash
+zsh -c '
+set -euo pipefail
+publisher_id="$(op read "op://Web/uni/CHROME_PUBLISHER_ID")"
+service_account_json="$(op read "op://Web/uni/CHROME_SERVICE_ACCOUNT_JSON")"
+
+[[ -n "$publisher_id" ]]
+printf "%s" "$service_account_json" | jq -e '\''
+  .type == "service_account" and
+  (.client_email | type == "string" and length > 0) and
+  (.private_key | type == "string" and startswith("-----BEGIN PRIVATE KEY-----")) and
+  (.token_uri == "https://oauth2.googleapis.com/token")
+'\'' >/dev/null
+
+echo "Chrome Web Store service account configuration: valid"
+'
+```
+
+成功時は次の1行だけが表示されます。
+
+```text
+Chrome Web Store service account configuration: valid
+```
+
+API v2移行後の本番公開が成功したら、不要になった旧`CHROME_CLIENT_ID`、`CHROME_CLIENT_SECRET`、`CHROME_REFRESH_TOKEN`フィールドを削除できます。
 
 ## GitHub Actionsを実行する
 


### PR DESCRIPTION
## Summary

Chrome Web Storeの公開処理を、ユーザーOAuth refresh tokenと旧APIに依存する構成から、Chrome Web Store API v2とサービスアカウント認証へ移行します。

Closes #51
Refs #53

## Background

2.1.5のChrome公開ジョブではOAuth認証情報の不整合により、パッケージのアップロード前に失敗しました。認証情報の再発行で復旧しましたが、従来構成には次の問題が残っていました。

- ユーザーが発行したrefresh tokenの失効・不整合に影響される
- `mobilefirstllc/cws-publish@latest`が旧Chrome Web Store APIを使用する
- Actionの参照が不変のcommit SHAではない
- アップロードだけで、審査提出まで行われない
- 認証・権限エラーがビルド後に判明する

## Changes

- Chrome Web Store API v2の`fetchStatus`、`upload`、`publish`を直接使用
- 1Passwordの`CHROME_PUBLISHER_ID`と`CHROME_SERVICE_ACCOUNT_JSON`からサービスアカウント認証
- ビルド前に認証、publisher、対象拡張機能へのアクセスをpreflight
- 非同期アップロードの完了待ちと状態検証を追加
- アップロード後に審査提出し、提出状態をログへ表示
- 手動実行に安全な`validate`モードを追加
  - 既定値は`validate`
  - 認証と`fetchStatus`だけを実行し、アップロードや公開は行わない
  - `publish`を明示した場合とGitHub Release時だけ公開処理を行う
- 使用する第三者GitHub Actionsをcommit SHAへ固定
- サービスアカウントの設定、検証、公開手順をドキュメント化

## External configuration already verified

秘密値をログへ出さず、次をローカルで確認済みです。

- 1Passwordの2つの参照を読み取り可能
- サービスアカウントJSON鍵の構造が正常
- Google OAuth短期アクセストークンの取得に成功
- API v2の`fetchStatus`で対象拡張機能へアクセス可能
- 対象拡張機能の状態は`PUBLISHED`、審査中submissionはなし

## Validation

- `npm run fmt`
- `npx prettier --check .github/workflows/publish-chrome.yml docs/chrome-web-store-release.md`
- `npm test` — 117 tests passed
- `npm run build`
- Workflow YAML parse
- `git diff --check`

## Post-merge verification

Issue #53の手順に従い、まず`validate`モードを手動実行してGitHub Actions上の認証を確認します。現在の2.1.5は公開済みのため再アップロードせず、次のバージョンのリリースでupload、review submission、publicationをend-to-end確認します。
